### PR TITLE
Add Conda environment support to Caliban

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,13 @@
-# 0.1.16 (IN PROGRESS)
+# 0.3.0 (in progress)
+
+- Added support for Conda dependencies
+  (https://github.com/google/caliban/pull/5). If you include `environment.yml`
+  in your project's folder Caliban will attempt to install all dependencies.
+- Caliban now uses a slimmer base image for GPU mode.
+- Base images for CPU and GPU modes now use Conda to manage the container's
+  virtual environment instead of `virtualenv`.
+
+# 0.2.0
 
 - Caliban now caches the service account key and ADC file; you should see faster
   builds, BUT you might run into trouble if you try to run multiple Caliban

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Train your first [machine learning
 model](https://www.tensorflow.org/tutorials/quickstart/beginner) in 2 lines:
 
 ```bash
-git clone https://github.com/google/caliban.git && cd caliban/tutorials/demo
+git clone https://github.com/google/caliban.git && cd caliban/tutorials/basic
 caliban run --nogpu mnist.py
 ```
 

--- a/caliban/cli.py
+++ b/caliban/cli.py
@@ -549,13 +549,15 @@ def generate_docker_args(job_mode: conf.JobMode,
   adc_loc = csdk.get_application_default_credentials_path()
   adc_path = adc_loc if os.path.isfile(adc_loc) else None
 
-  # TODO we may want to take a custom path, here, in addition to detecting it.
+  # TODO we may want to take custom paths, here, in addition to detecting them.
   reqs = "requirements.txt"
+  conda_env = "environment.yml"
 
   # Arguments that make their way down to caliban.docker.build_image.
   docker_args = {
       "extra_dirs": args.get("dir"),
       "requirements_path": reqs if os.path.exists(reqs) else None,
+      "conda_env_path": conda_env if os.path.exists(conda_env) else None,
       "caliban_config": conf.caliban_config(),
       "credentials_path": creds_path,
       "adc_path": adc_path,

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -1,3 +1,17 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # This builds the base images that we can use for development at Blueshift.
 # Tensorflow 2.1 by default, but we can override the image when we call docker.
 #
@@ -55,15 +69,20 @@ ENV PATH $PATH:${GCLOUD_LOC}/google-cloud-sdk/bin
 
 COPY scripts/bashrc /etc/bash.bashrc
 
-# This follows the style laid out here to set up a fresh, activated virtualenv
-# inside the image:
-# https://pythonspeed.com/articles/activate-virtualenv-dockerfile/
-ENV VIRTUAL_ENV=/opt/venv
-RUN python3 -m virtualenv --python=/usr/bin/python3 $VIRTUAL_ENV
+# Install Miniconda and prep the system to activate our custom environment.
+RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-py37_4.8.2-Linux-x86_64.sh -O ~/miniconda.sh && \
+  /bin/bash ~/miniconda.sh -b -p /opt/conda && \
+  rm ~/miniconda.sh && \
+  /opt/conda/bin/conda clean -tipsy && \
+  ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
+  echo ". /opt/conda/etc/profile.d/conda.sh" >> /etc/bash.bashrc && \
+  echo "conda activate caliban" >> /etc/bash.bashrc
 
-# There may be a better way - but this allows a user to install packages in the
-# virtualenv once it launches.
-RUN chmod -R 757 $VIRTUAL_ENV && mkdir /.cache && chmod -R 757 /.cache
+RUN yes | /opt/conda/bin/conda create --name caliban python=3.7 && /opt/conda/bin/conda clean --all
+
+# This allows a user to install packages in the conda environment once it
+# launches.
+RUN chmod -R 757 /opt/conda/envs/caliban && mkdir /.cache && chmod -R 757 /.cache
 
 # This is equivalent to activating the env.
-ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+ENV PATH /opt/conda/envs/caliban/bin:$PATH

--- a/dockerfiles/Dockerfile.gpu
+++ b/dockerfiles/Dockerfile.gpu
@@ -1,0 +1,69 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG UBUNTU_VERSION=18.04
+ARG CUDA=10.1
+
+FROM nvidia/cuda${ARCH:+-$ARCH}:${CUDA}-base-ubuntu${UBUNTU_VERSION} as base
+
+# ARCH and CUDA are specified again because the FROM directive resets ARGs
+# (but their default value is retained if set previously)
+ARG ARCH
+ARG CUDA
+ARG CUDNN=7.6.4.38-1
+ARG CUDNN_MAJOR_VERSION=7
+ARG LIB_DIR_PREFIX=x86_64
+ARG LIBNVINFER=6.0.1-1
+ARG LIBNVINFER_MAJOR_VERSION=6
+
+# Needed for string substitution
+SHELL ["/bin/bash", "-c"]
+
+# These dependencies come from the list at the official Tensorflow GPU base
+# image:
+# https://github.com/tensorflow/tensorflow/blob/master/tensorflow/tools/dockerfiles/dockerfiles/gpu.Dockerfile
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  build-essential \
+  cuda-command-line-tools-${CUDA/./-} \
+  # There appears to be a regression in libcublas10=10.2.2.89-1 which
+  # prevents cublas from initializing in TF. See
+  # https://github.com/tensorflow/tensorflow/issues/9489#issuecomment-562394257
+  libcublas10=10.2.1.243-1 \
+  cuda-nvrtc-${CUDA/./-} \
+  cuda-cufft-${CUDA/./-} \
+  cuda-curand-${CUDA/./-} \
+  cuda-cusolver-${CUDA/./-} \
+  cuda-cusparse-${CUDA/./-} \
+  curl \
+  libcudnn7=${CUDNN}+cuda${CUDA} \
+  libfreetype6-dev \
+  libhdf5-serial-dev \
+  libzmq3-dev \
+  pkg-config \
+  software-properties-common \
+  unzip \
+  libnvinfer${LIBNVINFER_MAJOR_VERSION}=${LIBNVINFER}+cuda${CUDA} \
+  libnvinfer-plugin${LIBNVINFER_MAJOR_VERSION}=${LIBNVINFER}+cuda${CUDA} \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+
+# For CUDA profiling, TensorFlow requires CUPTI.
+ENV LD_LIBRARY_PATH /usr/local/cuda/extras/CUPTI/lib64:/usr/local/cuda/lib64:$LD_LIBRARY_PATH
+
+# Link the libcuda stub to the location where tensorflow is searching for it and reconfigure
+# dynamic linker run-time bindings
+RUN ln -s /usr/local/cuda/lib64/stubs/libcuda.so /usr/local/cuda/lib64/stubs/libcuda.so.1 \
+  && echo "/usr/local/cuda/lib64/stubs" > /etc/ld.so.conf.d/z-cuda-stubs.conf \
+  && ldconfig

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,13 +2,6 @@
 hypothesis
 ipython
 pre-commit
-<<<<<<< Updated upstream
 pytest==5.4.3
 pytest-cov==2.10.0
-=======
-pytest
-pytest-cov
-sphinx
-sphinx-argparse
->>>>>>> Stashed changes
 twine

--- a/scripts/build_dockerfiles.sh
+++ b/scripts/build_dockerfiles.sh
@@ -19,7 +19,14 @@
 # Error out if any of the commands fail.
 set -e
 
-docker build -t gcr.io/blueshift-playground/blueshift:cpu -f- . <Dockerfile
+# GPU base-base, with all CUDA dependencies required for GPU work. Built off of the NVIDIA base image.
+docker build -t gcr.io/blueshift-playground/blueshift:gpu-base -f- . <dockerfiles/Dockerfile.gpu
+docker push gcr.io/blueshift-playground/blueshift:gpu-base
+
+# CPU base image for jobs.
+docker build -t gcr.io/blueshift-playground/blueshift:cpu -f- . <dockerfiles/Dockerfile
 docker push gcr.io/blueshift-playground/blueshift:cpu
-docker build --build-arg BASE_IMAGE=tensorflow/tensorflow:2.2.0-gpu -t gcr.io/blueshift-playground/blueshift:gpu -f- . <Dockerfile
+
+# GPU image.
+docker build --build-arg BASE_IMAGE=gcr.io/blueshift-playground/blueshift:gpu-base -t gcr.io/blueshift-playground/blueshift:gpu -f- . <dockerfiles/Dockerfile
 docker push gcr.io/blueshift-playground/blueshift:gpu


### PR DESCRIPTION
This PR:

- modifies the Dockerfile to include `miniconda` in the base images
- adds a new Dockerfile that creates a slimmed-down base image for our GPU jobs. (The big difference here is that the tensorflow dependency is cut, saving us 600MB)
- adds support for `conda` dependencies via `environment.yml`, if it's present in the folder.