### PR TITLE
Move credentials after build dependencies, controlled by calibanconfig

### DIFF
--- a/caliban/docker.py
+++ b/caliban/docker.py
@@ -541,10 +541,6 @@ USER {uid}:{gid}
       "c_home": container_home(),
       "creds_dir": CREDS_DIR
   })
-  dockerfile += _credentials_entries(uid,
-                                     gid,
-                                     adc_path=adc_path,
-                                     credentials_path=credentials_path)
 
   dockerfile += _dependency_entries(workdir,
                                     uid,
@@ -553,18 +549,23 @@ USER {uid}:{gid}
                                     conda_env_path=conda_env_path,
                                     setup_extras=setup_extras)
 
-  if inject_notebook.value != 'none':
-    install_lab = inject_notebook == NotebookInstall.lab
-    dockerfile += _notebook_entries(lab=install_lab, version=jupyter_version)
-
-  if extra_dirs is not None:
-    dockerfile += _extra_dir_entries(workdir, uid, gid, extra_dirs)
-
   dockerfile += _custom_packages(uid,
                                  gid,
                                  packages=c.apt_packages(
                                      caliban_config, job_mode),
                                  shell=shell)
+
+  if extra_dirs is not None:
+    dockerfile += _extra_dir_entries(workdir, uid, gid, extra_dirs)
+
+  if inject_notebook.value != 'none':
+    install_lab = inject_notebook == NotebookInstall.lab
+    dockerfile += _notebook_entries(lab=install_lab, version=jupyter_version)
+
+  dockerfile += _credentials_entries(uid,
+                                     gid,
+                                     adc_path=adc_path,
+                                     credentials_path=credentials_path)
 
   if package is not None:
     # The actual entrypoint and final copied code.


### PR DESCRIPTION
Dependencies are much more expensive to change than credentials. This PR moves the credential injection after dependency fetching.

This is a decent idea, I think, BUT it has a problem. If you have private dependencies in a google Source Cloud Repository, you need the credentials to come before the `pip install` so that `git` can use `gcloud` for authentication.

@ajslone , I'm going to vote that we:

- make this change here, **but only after**
- we add a setting in `.calibanconfig.json` that allows you to move this earlier if you need it there.

I am a little worried at configuration options starting to increase. What do you think?