### PR TITLE
Fix `caliban notebook` and prep apt_packages for packages like texlive

### DIFF
--- a/caliban/docker.py
+++ b/caliban/docker.py
@@ -95,10 +95,10 @@ ShellData = NamedTuple("ShellData", [("executable", str),
 def apt_install(*packages: str) -> str:
   """Returns a command that will install the supplied list of packages without
   requiring confirmation or any user interaction.
-
   """
   package_str = ' '.join(packages)
-  return "apt-get install --yes --no-install-recommends {}".format(package_str)
+  no_prompt = "DEBIAN_FRONTEND=noninteractive"
+  return f"{no_prompt} apt-get install --yes --no-install-recommends {package_str}"
 
 
 def apt_command(commands: List[str]) -> List[str]:
@@ -107,7 +107,7 @@ def apt_command(commands: List[str]) -> List[str]:
 
   """
   update = ["apt-get update"]
-  cleanup = ["rm -rf /var/lib/apt/lists/*"]
+  cleanup = ["apt-get clean", "rm -rf /var/lib/apt/lists/*"]
   return update + commands + cleanup
 
 
@@ -1025,7 +1025,7 @@ def run_notebook(job_mode: c.JobMode,
   docker_args = ["-p", "{}:{}".format(port, port)] + run_args
 
   run_interactive(job_mode,
-                  entrypoint="/opt/venv/bin/python",
+                  entrypoint="/opt/conda/envs/caliban/bin/python",
                   entrypoint_args=jupyter_args,
                   run_args=docker_args,
                   inject_notebook=inject_arg,

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -38,14 +38,15 @@ LABEL maintainer="samritchie@google.com"
 ENV LANG C.UTF-8
 
 # Install git so that users can declare git dependencies, and python3 plus
-# python3-venv so we can generate an isolated Python environment inside
+# python3-virtualenv so we can generate an isolated Python environment inside
 # the container.
 RUN apt-get update && apt-get install -y --no-install-recommends \
   git \
   python3 \
   python3-virtualenv \
-  wget && \
-  rm -rf /var/lib/apt/lists/*
+  wget \
+  && apt-get clean && \
+  && rm -rf /var/lib/apt/lists/*
 
 # Some tools expect a "python" binary.
 RUN ln -s $(which python3) /usr/local/bin/python


### PR DESCRIPTION
This PR:

- fixes the python binary that `caliban notebook` points to (now that we use conda)
- adds `DEBIAN_FRONTEND=noninteractive` to the `apt-get` command, so that packages like `texlive` won't freeze and wait for you to specify a timezone.