### PR TITLE
clean up imports, add `docker run hello-world`

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,24 @@ Caliban executes your code inside a "container", managed by
   Docker](https://caliban.readthedocs.io/en/latest/getting_started/prerequisites.html#docker)
   and start Docker running on your machine.)
 
+Make sure Docker is correctly installed, configured and running by executing the
+following command:
+
+```bash
+docker run hello-world
+```
+
+You should see output that looks like this:
+
+```text
+...
+Hello from Docker!
+This message shows that your installation appears to be working correctly.
+...
+```
+
 ### Python 3.6
+
 Make sure your Python version is up to date:
 
 ```bash
@@ -428,8 +445,8 @@ your machine:
 * [`caliban
   status`](https://caliban.readthedocs.io/en/latest/cli/caliban_status.html)
   displays information about all jobs submitted by Caliban, and makes it easy to
-  interact with large groups of experiments. Use `caliban status` when need to
-  cancel pending jobs, or re-build a container and resubmit a batch of
+  interact with large groups of experiments. Use `caliban status` when you need
+  to cancel pending jobs, or re-build a container and resubmit a batch of
   experiments after fixing a bug.
 
 ## Disclaimer

--- a/caliban/cli.py
+++ b/caliban/cli.py
@@ -14,9 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Command line parser for the Caliban app."""
+import argparse
 import os
 import sys
-import argparse
 from argparse import REMAINDER
 from typing import Any, Dict, List, Optional, Union
 
@@ -27,12 +27,11 @@ from blessings import Terminal
 import caliban.cloud.types as ct
 import caliban.config as conf
 import caliban.docker as docker
-import caliban.util as u
 import caliban.gke as gke
 import caliban.gke.constants as gke_k
-import caliban.gke.utils as gke_u
 import caliban.gke.types as gke_t
-
+import caliban.gke.utils as gke_u
+import caliban.util as u
 from caliban import __version__
 
 t = Terminal()

--- a/caliban/cloud/types.py
+++ b/caliban/cloud/types.py
@@ -17,8 +17,7 @@
 
 import argparse
 from enum import Enum
-from typing import (Any, Callable, Dict, Iterable, List, NamedTuple, Optional,
-                    Set, Tuple, Union)
+from typing import Callable, List, NamedTuple, Optional, Set, Union
 
 import caliban.util as u
 

--- a/caliban/gke/cli.py
+++ b/caliban/gke/cli.py
@@ -13,36 +13,18 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-#!/usr/bin/python
-#
-# Copyright 2020 Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 """gke cli support"""
 
 import json
 import logging
-import pprint as pp
-import re
 import os
-from typing import List, Optional, Tuple, Iterable, Dict, Any
+import pprint as pp
+from datetime import datetime
+from typing import Any, Dict, List, Optional
 
 import googleapiclient
 from google.auth.credentials import Credentials
-from googleapiclient import discovery
-from kubernetes.client import V1Job, V1JobSpec, V1ObjectMeta, V1Pod
-from datetime import datetime
+from kubernetes.client import V1Job
 
 import caliban.cli as cli
 import caliban.config as conf
@@ -50,14 +32,10 @@ import caliban.gke.constants as k
 import caliban.gke.utils as utils
 import caliban.util as u
 from caliban.cloud.core import generate_image_tag
-from caliban.cloud.types import parse_machine_type
 from caliban.gke.cluster import Cluster
-from caliban.gke.types import CredentialsData, NodeImage
-
-from caliban.history.utils import (get_sql_engine, get_mem_engine,
-                                   session_scope, generate_container_spec,
-                                   create_experiments)
-import caliban.history.types as ht
+from caliban.history.utils import (create_experiments, generate_container_spec,
+                                   get_mem_engine, get_sql_engine,
+                                   session_scope)
 
 
 # ----------------------------------------------------------------------------

--- a/caliban/gke/cluster.py
+++ b/caliban/gke/cluster.py
@@ -17,50 +17,34 @@
 
 import json
 import logging
-import os
-import pprint as pp
 import re
-import sys
-from argparse import REMAINDER, ArgumentTypeError
-from enum import Enum
-from time import sleep
-from copy import deepcopy
-from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple
 
-import google
-import google.auth.environment_vars as auth_env
 import googleapiclient
 import kubernetes
 import requests
 # silence warnings about ssl connection not being verified
 import urllib3
 import yaml
-from google.auth import compute_engine
 from google.auth.credentials import Credentials
 from google.cloud.container_v1 import ClusterManagerClient
-from google.cloud.container_v1.types import Cluster as GKECluster
 from google.cloud.container_v1.types import NodePool
-from google.oauth2 import service_account
 from googleapiclient import discovery
 from googleapiclient.http import HttpRequest
 from kubernetes.client import (V1Container, V1DaemonSet, V1EnvVar, V1Job,
                                V1JobSpec, V1ObjectMeta, V1Pod, V1PodSpec,
                                V1PodTemplateSpec, V1ResourceRequirements,
                                V1Toleration)
-
 from kubernetes.client.api_client import ApiClient
 
-import caliban
 import caliban.config as conf
 import caliban.gke.constants as k
 import caliban.gke.utils as utils
-import caliban.util as u
 from caliban.cloud.types import (GPU, TPU, Accelerator, GPUSpec, MachineType,
-                                 TPUSpec, parse_machine_type)
+                                 TPUSpec)
 from caliban.gke.types import NodeImage, OpStatus, ReleaseChannel
 from caliban.gke.utils import trap
-from caliban.history.types import (JobSpec, Job, Experiment, Platform,
-                                   JobStatus)
+from caliban.history.types import Experiment, Job, JobSpec, JobStatus, Platform
 
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 

--- a/caliban/gke/constants.py
+++ b/caliban/gke/constants.py
@@ -13,28 +13,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-#!/usr/bin/python
-#
-# Copyright 2020 Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 """constants for gke"""
 
 import re
 
-from caliban.config import JobMode, DEFAULT_MACHINE_TYPE
-from caliban.cloud.types import GPUSpec, GPU
+from caliban.cloud.types import GPU, GPUSpec
+from caliban.config import DEFAULT_MACHINE_TYPE, JobMode
 from caliban.gke.types import ReleaseChannel
 
 COMPUTE_SCOPE_URL = 'https://www.googleapis.com/auth/compute'

--- a/caliban/gke/utils.py
+++ b/caliban/gke/utils.py
@@ -17,38 +17,33 @@
 
 from __future__ import absolute_import
 
-from typing import Dict, List, Optional, Any, Tuple
+import argparse
+import json
 import logging
-from urllib.parse import urlencode, urlparse
-from time import sleep
-import re
 import os
 import pprint as pp
-import json
+import re
+from time import sleep
+from typing import Any, Dict, List, Optional
+from urllib.parse import urlencode, urlparse
+
+import google
 import yaml
-import argparse
+from google.auth._cloud_sdk import get_application_default_credentials_path
+from google.auth._default import (_AUTHORIZED_USER_TYPE, _SERVICE_ACCOUNT_TYPE,
+                                  load_credentials_from_file)
+from google.cloud.container_v1 import ClusterManagerClient
+from google.cloud.container_v1.types import Cluster as GKECluster
+from google.oauth2 import service_account
+from googleapiclient import discovery
+from kubernetes.client import V1Job
+from kubernetes.client.api_client import ApiClient
 from yaspin import yaspin
 from yaspin.spinners import Spinners
 
-import google
-import googleapiclient
-from googleapiclient import discovery
-from googleapiclient.http import HttpRequest
-from google.auth.credentials import Credentials
-from google.auth._default import (load_credentials_from_file,
-                                  _AUTHORIZED_USER_TYPE, _SERVICE_ACCOUNT_TYPE)
-from google.oauth2 import service_account
-from google.cloud.container_v1.types import Cluster as GKECluster, NodePool
-from google.cloud.container_v1 import ClusterManagerClient
-from google.auth._cloud_sdk import get_application_default_credentials_path
-
-from kubernetes.client import V1Job
-from kubernetes.client.api_client import ApiClient
-
 import caliban.gke.constants as k
-from caliban.gke.types import (NodeImage, OpStatus, CredentialsData,
-                               ReleaseChannel)
-from caliban.cloud.types import (GPU, GPUSpec, TPU, TPUSpec)
+from caliban.cloud.types import GPU, TPU, GPUSpec, TPUSpec
+from caliban.gke.types import (CredentialsData, NodeImage, OpStatus)
 
 
 # ----------------------------------------------------------------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -49,7 +49,7 @@ laptop or workstation:
 
 * :doc:`/cli/caliban_status` displays information about all jobs submitted by
   Caliban, and makes it easy to interact with large groups of experiments. Use
-  :doc:`/cli/caliban_status` when need to cancel pending jobs, or re-build a
+  :doc:`/cli/caliban_status` when you need to cancel pending jobs, or re-build a
   container and resubmit a batch of experiments after fixing a bug.
 
 These all work from :doc:`your Macbook Pro <explore/mac>`. (Yes, you can build

--- a/tests/caliban/test_cli.py
+++ b/tests/caliban/test_cli.py
@@ -14,22 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#!/usr/bin/python
-#
-# Copyright 2020 Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 import unittest
 
 import caliban.cli as c

--- a/tests/caliban/test_docker.py
+++ b/tests/caliban/test_docker.py
@@ -14,22 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#!/usr/bin/python
-#
-# Copyright 2020 Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 import unittest
 
 import caliban.docker as d


### PR DESCRIPTION
This PR:

- Fixes a couple of typos
- sorts imports and removes unused imports in various files
- adds a note to the README.md about how to check that Docker is installed and running correctly.