### PR TITLE
Flush buffered docker build stdout + fix close error from #29

### DIFF
--- a/caliban/util.py
+++ b/caliban/util.py
@@ -397,11 +397,15 @@ def capture_stdout(cmd: List[str],
   - return code of the process
 
   """
+  if file is None:
+    file = sys.stdout
+
   buf = io.StringIO()
   ret_code = None
   with subprocess.Popen(cmd,
                         stdin=subprocess.PIPE,
                         stdout=subprocess.PIPE,
+                        stderr=subprocess.STDOUT,
                         bufsize=1,
                         encoding="utf-8") as p:
     if input_str:
@@ -411,6 +415,9 @@ def capture_stdout(cmd: List[str],
     for line in p.stdout:
       print(line, end='', file=file)
       buf.write(line)
+
+    # flush to force the contents to display.
+    file.flush()
 
     while p.poll() is None:
       # Process hasn't exited yet, let's wait some
@@ -677,6 +684,9 @@ class TqdmFile(object):
 
   def isatty(self):
     return getattr(self.file, "isatty", lambda: False)()
+
+  def close(self):
+    return getattr(self.file, "close", lambda: None)()
 
 
 def config_logging():

--- a/tests/caliban/test_util.py
+++ b/tests/caliban/test_util.py
@@ -41,7 +41,7 @@ def test_capture_stdout():
   assert code == 0
 
   # Verify that the stdout is reported to the supplied file, and that it's
-  # captured by the function adn returned correctly.
+  # captured by the function and returned correctly.
   assert ret_string == "hello!\n"
   assert buf.getvalue() == ret_string
 

--- a/tests/caliban/test_util.py
+++ b/tests/caliban/test_util.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import io
 import itertools
 import re
 import unittest
@@ -32,6 +33,23 @@ ne_text_set = st.sets(st.text(min_size=1), min_size=1)
 
 def non_empty_dict(vgen):
   return st.dictionaries(st.text(), vgen, min_size=1)
+
+
+def test_capture_stdout():
+  buf = io.StringIO()
+  ret_string, code = u.capture_stdout(["echo", "hello!"], file=buf)
+  assert code == 0
+
+  # Verify that the stdout is reported to the supplied file, and that it's
+  # captured by the function adn returned correctly.
+  assert ret_string == "hello!\n"
+  assert buf.getvalue() == ret_string
+
+
+def test_capture_stdout_input():
+  ret_string, code = u.capture_stdout(["cat"], input_str="hello!")
+  assert code == 0
+  assert ret_string.rstrip() == "hello!"
 
 
 class UtilTestSuite(unittest.TestCase):


### PR DESCRIPTION
This PR fixes the `close()` error reported in #29 , and forces the `docker build` step, and anything that uses `u.capture_stdout()`, to flush its buffer before proceeding. Otherwise the `docker build` output always appears at the end of any piped stdout.