### PR TITLE
Fix progress bar interactions in `caliban run` subprocesses

### DIFF
--- a/caliban/docker.py
+++ b/caliban/docker.py
@@ -670,7 +670,8 @@ def _run_cmd(job_mode: c.JobMode,
     run_args = []
 
   runtime = ["--runtime", "nvidia"] if c.gpu(job_mode) else []
-  return ["docker", "run"] + runtime + ["--ipc", "host"] + run_args
+  return ["docker", "run"
+         ] + runtime + ["--ipc", "host", "-e", "PYTHONUNBUFFERED=1"] + run_args
 
 
 def _home_mount_cmds(enable_home_mount: bool) -> List[str]:

--- a/caliban/util.py
+++ b/caliban/util.py
@@ -397,11 +397,15 @@ def capture_stdout(cmd: List[str],
   - return code of the process
 
   """
+  if file is None:
+    file = sys.stdout
+
   buf = io.StringIO()
   ret_code = None
   with subprocess.Popen(cmd,
                         stdin=subprocess.PIPE,
                         stdout=subprocess.PIPE,
+                        stderr=subprocess.STDOUT,
                         bufsize=1,
                         encoding="utf-8") as p:
     if input_str:
@@ -411,6 +415,9 @@ def capture_stdout(cmd: List[str],
     for line in p.stdout:
       print(line, end='', file=file)
       buf.write(line)
+
+    # flush to force the contents to display.
+    file.flush()
 
     while p.poll() is None:
       # Process hasn't exited yet, let's wait some
@@ -677,6 +684,9 @@ class TqdmFile(object):
 
   def isatty(self):
     return getattr(self.file, "isatty", lambda: False)()
+
+  def close(self):
+    return getattr(self.file, "close", lambda: None)()
 
 
 def config_logging():

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ REQUIRED_PACKAGES = [
     'commentjson',
     'google-api-python-client',
     'pyyaml',
-    'tqdm',
+    'tqdm>=4.45.0',
     'kubernetes>=10.0.1',
     'google-auth>=1.18.0',
     'google-cloud-core>=1.0.3',

--- a/tests/caliban/test_util.py
+++ b/tests/caliban/test_util.py
@@ -41,7 +41,7 @@ def test_capture_stdout():
   assert code == 0
 
   # Verify that the stdout is reported to the supplied file, and that it's
-  # captured by the function adn returned correctly.
+  # captured by the function and returned correctly.
   assert ret_string == "hello!\n"
   assert buf.getvalue() == ret_string
 

--- a/tests/caliban/test_util.py
+++ b/tests/caliban/test_util.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import io
 import itertools
 import re
 import unittest
@@ -32,6 +33,23 @@ ne_text_set = st.sets(st.text(min_size=1), min_size=1)
 
 def non_empty_dict(vgen):
   return st.dictionaries(st.text(), vgen, min_size=1)
+
+
+def test_capture_stdout():
+  buf = io.StringIO()
+  ret_string, code = u.capture_stdout(["echo", "hello!"], file=buf)
+  assert code == 0
+
+  # Verify that the stdout is reported to the supplied file, and that it's
+  # captured by the function adn returned correctly.
+  assert ret_string == "hello!\n"
+  assert buf.getvalue() == ret_string
+
+
+def test_capture_stdout_input():
+  ret_string, code = u.capture_stdout(["cat"], input_str="hello!")
+  assert code == 0
+  assert ret_string.rstrip() == "hello!"
 
 
 class UtilTestSuite(unittest.TestCase):

--- a/tutorials/basic/mnist.py
+++ b/tutorials/basic/mnist.py
@@ -17,10 +17,12 @@
 https://www.tensorflow.org/tutorials/quickstart/beginner.
 
 """
+import warnings
 
 import tensorflow as tf
-
 from absl import app, flags
+
+warnings.filterwarnings("ignore", category=DeprecationWarning)
 
 FLAGS = flags.FLAGS
 
@@ -58,7 +60,7 @@ def main(_):
   print(
       f'Training model with learning rate={FLAGS.learning_rate} for {FLAGS.epochs} epochs.'
   )
-  model.fit(x_train, y_train, epochs=FLAGS.epochs, verbose=2)
+  model.fit(x_train, y_train, epochs=FLAGS.epochs)
 
   print('Model performance: ')
   model.evaluate(x_test, y_test, verbose=2)


### PR DESCRIPTION
This PR makes a few changes that allow us to use `caliban run` to execute scripts with (single) progress bars or other updating progress meters that use carriage returns to modify lines.

It's not PERFECT — if you have a progress bar and use `tqdm.write("HI!")` inside, for example, you'll trigger a newline, instead of the nice, flowing-upward output above the inner progress bar that you get when you run `tqdm` locally. But that is a challenge for another day.

I was able to package this pretty cleanly, I think, into `TqdmFile`, but it does require some fiddling in `capture_output` as well.

![2020-06-26 09 48 50](https://user-images.githubusercontent.com/69635/85877300-2a3e7300-b794-11ea-9792-4cf3ae5e4263.gif)