### PR TITLE
Add support for gcloud auth login to enable job submission credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.2.7
+
+- Caliban now authenticates AI Platform job submissions using the authentication
+  provided by `gcloud auth login`, rather than requiring a service account key.
+  This significantly simplifies the setup required for a first time user.
+
 # 0.2.6
 
 - Prepared for a variety of base images by setting up a cloud build matrix:

--- a/caliban/cli.py
+++ b/caliban/cli.py
@@ -459,9 +459,9 @@ def _validate_machine_type(gpu_spec: Optional[ct.GPUSpec],
       # prefixes stick together.
       allowed = u.enum_vals(gpu_spec.allowed_machine_types())
       allowed.sort()
-      u.err("\n'{}' isn't a valid machine type ".format(machine_type.value) +
-            "for {} {} GPUs.\n\n".format(gpu_spec.count, gpu_spec.gpu.name))
-      u.err(ct.with_gpu_advice_suffix("Try one of these: {}".format(allowed)))
+      u.err(f"\n'{machine_type.value}' isn't a valid machine type " +
+            f"for {gpu_spec.count} {gpu_spec.gpu.name} GPUs.\n\n")
+      u.err(ct.with_advice_suffix("gpu", f"Try one of these: {allowed}"))
       u.err("\n")
       sys.exit(1)
 

--- a/docs/cloud/service_account.rst
+++ b/docs/cloud/service_account.rst
@@ -1,0 +1,73 @@
+Creating a Service Account Key
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This page describes how to generate and install a `Service Account Key
+<https://www.google.com/search?q=service+account+key+google&oq=service+account+key+google&aqs=chrome..69i57j69i60l2.1592j0j4&sourceid=chrome&ie=UTF-8>`_.
+A service account key is a sort of "passport" that your code can use to
+authenticate itself during communication with Google's Cloud services.
+
+You can also provide Caliban with a service account key via the ``--cloud_key``
+flag. If you do, Caliban will use this service account to authenticate itself
+with AI Platform when submitting jobs. (You would do this if you wanted to
+submit to some project you didn't own, for example.)
+
+To create a service account key, visit the `Service Accounts page
+<https://console.cloud.google.com/iam-admin/serviceaccounts?_ga=2.94132893.1698699355.1592403366-805054138.1592403366>`_
+and select the project you created earlier.
+
+Click "Create Service Account" at the top of the page:
+
+.. image:: /_static/img/cloud/activate.png
+  :width: 600
+  :align: center
+  :alt: Activate Billing
+
+At the next form, under **"Service Account Name"**, type something like
+**totoro_key** and click **"Create"**.
+
+This will bring up a page titled **"Service Account Permissions"**. Select
+**Project > Owner** from the list:
+
+.. image:: /_static/img/cloud/service_acct_permissions.png
+  :width: 600
+  :align: center
+  :alt: Service Account Permissions
+
+Then click **"Continue"** and **"Done"**. You now have a service account. You'll
+need to download it to your machine for Caliban to use it.
+
+Downloading the Service Account Key
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Click on the hyperlinked name of the key - something like
+``totoro-key@totoro-lives.iam.gserviceaccount.com`` - in the service accounts
+list.
+
+Near the bottom of the page, click "Add Key" > "Create New Key":
+
+.. image:: /_static/img/cloud/create_new_key.png
+  :width: 600
+  :align: center
+  :alt: Create New Key
+
+Select **"JSON"** for key type and click **"Create"**. This will download a file
+with a name like ``totoro-lives-3df07b8c97a0.json`` to your machine.
+
+Find the file in your terminal (probably in your Downloads folder) and run the
+following command to move it to a nice, easy to read location:
+
+.. code-block:: bash
+
+   mv [NEW_FILENAME].json ~/.config/service_key.json
+
+To make this key accessible to Caliban, you'll need to set a variable called
+``GOOGLE_APPLICATION_CREDENTIALS`` in your shell to the path of your new service
+account key. Add the following line to your `~/.bashrc`:
+
+.. code-block:: bash
+
+   export GOOGLE_APPLICATION_CREDENTIALS=$HOME/.config/service_key.json
+
+If Caliban sees this environment variable set, it will go ahead and bake these
+credentials into your container, making them accessible to your code even inside
+the Docker environment.

--- a/docs/explore/gcloud.rst
+++ b/docs/explore/gcloud.rst
@@ -16,8 +16,8 @@ authentication within Docker containers.
 "Application Default Credentials", or ADC Credentials. See :doc:`../cloud/adc`
 for more information.
 
-.. NOTE:: to set up service account keys, visit the :ref:`service
-   account instructions <Service Account Key>`. To generate application default
+.. NOTE:: to set up service account keys, visit the :doc:`service
+   account instructions </cloud/service_account>`. To generate application default
    credentials on your machine, simply run ``gcloud auth application-default
    login`` at your terminal, as described `in the Google Cloud docs
    <https://cloud.google.com/sdk/gcloud/reference/auth/application-default/login>`_.
@@ -55,10 +55,10 @@ able to use the GCloud Python API or the ``gsutil`` or ``gcloud`` commands insid
 the container.
 
 As noted above, if you don't have this variable set up yet and want to get it
-working, check out the :ref:`service account instructions <Service Account
-Key>`. To generate application default credentials on your machine, simply run
-``gcloud auth application-default login`` at your terminal, as described `in the
-Cloud docs
+working, check out the :doc:`service account instructions
+</cloud/service_account>`. To generate application default credentials on your
+machine, simply run ``gcloud auth application-default login`` at your terminal,
+as described `in the Cloud docs
 <https://cloud.google.com/sdk/gcloud/reference/auth/application-default/login>`_.
 
 GCloud SDK

--- a/docs/getting_started/cloud.rst
+++ b/docs/getting_started/cloud.rst
@@ -110,73 +110,6 @@ Click `this link to Enable the AI Platform Jobs API
 <https://console.cloud.google.com/ai-platform/ml-enable-api/jobs>`_ by clicking
 "Enable API" and waiting for the spinner to stop.
 
-Create a Service Account Key
-----------------------------
-
-Next you'll need to create a `Service Account Key
-<https://www.google.com/search?q=service+account+key+google&oq=service+account+key+google&aqs=chrome..69i57j69i60l2.1592j0j4&sourceid=chrome&ie=UTF-8>`_.
-A service account key is a sort of "passport" that Caliban will use to
-authenticate your requests when submitting jobs to Google Cloud.
-
-To create your service account key, visit the `Service Accounts page
-  <https://console.cloud.google.com/iam-admin/serviceaccounts?_ga=2.94132893.1698699355.1592403366-805054138.1592403366>`_
-  and select the project you created earlier.
-
-Click "Create Service Account" at the top of the page:
-
-.. image:: /_static/img/cloud/activate.png
-  :width: 600
-  :align: center
-  :alt: Activate Billing
-
-At the next form, under **"Service Account Name"**, type something like
-**totoro_key** and click **"Create"**.
-
-This will bring up a page titled **"Service Account Permissions"**. Select
-**Project > Owner** from the list:
-
-.. image:: /_static/img/cloud/service_acct_permissions.png
-  :width: 600
-  :align: center
-  :alt: Service Account Permissions
-
-Then click **"Continue"** and **"Done"**. You now have a service account. You'll
-need to download it to your machine for Caliban to use it.
-
-Downloading the Service Account Key
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Click on the hyperlinked name of the key - something like
-``totoro-key@totoro-lives.iam.gserviceaccount.com`` - in the service accounts
-list.
-
-Near the bottom of the page, click "Add Key" > "Create New Key":
-
-.. image:: /_static/img/cloud/create_new_key.png
-  :width: 600
-  :align: center
-  :alt: Create New Key
-
-Select **"JSON"** for key type and click **"Create"**. This will download a file
-with a name like ``totoro-lives-3df07b8c97a0.json`` to your machine.
-
-Find the file in your terminal (probably in your Downloads folder) and run the
-following command to move it to a nice, easy to read location:
-
-.. code-block:: bash
-
-   mv [NEW_FILENAME].json ~/.config/service_key.json
-
-To make this key accessible to Caliban, you'll need to set a variable called
-``GOOGLE_APPLICATION_CREDENTIALS`` in your shell to the path of your new service
-account key. Add the following line to your `~/.bashrc`:
-
-.. code-block:: bash
-
-   export GOOGLE_APPLICATION_CREDENTIALS=$HOME/.config/service_key.json
-
-One step remains before we can submit jobs to Cloud AI Platform.
-
 Install the Cloud SDK
 ---------------------
 
@@ -254,15 +187,13 @@ your terminal. You should see your email address listed as the active account:
    To set the active account, run:
        $ gcloud config set account `ACCOUNT`
 
-As a final step, confirm that you've set the following two or three environment
-variables. (If you set a custom region above, add it here as a ``$REGION``
-variable).
+As a final step, confirm that you've set the following environment variables.
+(If you set a custom region above, add it here as a ``$REGION`` variable).
 
 .. code-block:: bash
 
    export REGION="us-central1"
    export PROJECT_ID="research-3141"
-   export GOOGLE_APPLICATION_CREDENTIALS="$HOME/.config/devkey.json"
 
 If you have all of this, you're set!
 

--- a/docs/gke/prereq.rst
+++ b/docs/gke/prereq.rst
@@ -8,5 +8,5 @@ Required Permissions
 
 To create and use a GKE cluster, you'll need to modify your service account key
 to give it Account Owner permissions. Those instructions live at the
-:ref:`Service Account Key` docs page. Note that this only applies if you are
+:doc:`/cloud/service_account` docs page. Note that this only applies if you are
 using a service account key.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -136,6 +136,7 @@ with Caliban.
    cloud/gpu_specs
    cloud/ai_platform_tpu
    cloud/rate_limit
+   cloud/service_account
    cloud/adc
    cloud/bucket
 


### PR DESCRIPTION
This PR adds an additional authentication method for ai platform job submission. We can now grab creds directly from the `gcloud auth login` flow, instead of requiring that the user generate a service account key for authentication.

I've updated the documentation to reflect this new feature.