### PR TITLE
Split `--docker_run_args` on white space

### DIFF
--- a/caliban/cli.py
+++ b/caliban/cli.py
@@ -148,7 +148,7 @@ def no_cache_arg(parser):
 def docker_run_arg(parser):
   """Adds a command that accepts arguments to pass directly to `docker run`."""
   parser.add_argument("--docker_run_args",
-                      type=lambda s: s.split(" "),
+                      type=lambda s: s.split(),
                       help="String of args to add to Docker.")
 
 


### PR DESCRIPTION
Split `--docker_run_args` on any white space (and not just single spaces). See <https://docs.python.org/3.8/library/stdtypes.html#str.split> for details.

This does not introduce spurious empty arguments when multiple spaces are used to separate docker run args (as in `--volume  a:b`, with two spaces), and also ignores leading and trailing spaces (as in ` -v a:b`). The latter should also help with the warning described in <https://caliban.readthedocs.io/en/latest/recipes/local_dir.html>, "[...] if you pass -v instead of --volume [...]" since it allows using `-v` if you add a space in front of it.