### PR TITLE
Improved documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,8 +49,9 @@ make lint
 
 ## Documentation
 
-We use Sphinx to generate docs. To get live reloading working, use
-[sphinx-reload](https://pypi.org/project/sphinx-reload/):
+We use Sphinx to generate docs. If you want to live-preview your changes to the
+documentation as you are editing, you can use
+[sphinx-reload](https://pypi.org/project/sphinx-reload/). To get this working:
 
 ```bash
 pipx install sphinx-reload
@@ -59,8 +60,12 @@ pipx install sphinx-reload
 Then, inside the caliban folder:
 
 ```bash
+make build
 sphinx-reload docs
 ```
+
+If all goes well, `sphinx-reload` will tell you it is serving the documentation
+on a port, which you can listen into from your browser.
 
 ## Publishing Caliban
 

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ clean-files:
 .PHONY: install
 install:
 	rm -rf $(ENV_NAME)
-	virtualenv -p python3.6 $(ENV_NAME)
+	virtualenv -p python3 $(ENV_NAME)
 	$(PIP) install -r requirements-dev.txt
 	$(PIP) install -r docs/requirements.txt
 	$(PIP) install -e .

--- a/docs/cli/caliban_shell.rst
+++ b/docs/cli/caliban_shell.rst
@@ -84,3 +84,11 @@ prevent you from getting too far.
    will use your ``$SHELL`` environment variable to pick a default; to override
    the default, you can always pass the ``--shell`` argument, like this:
    ``caliban shell --shell bash``.
+
+One potential issue resulting from the fact that your home directory will mount
+into the container is that some binaries from your ``$HOME``  directory might
+leak into the container.  For example, we have seen a case in which, in trying
+to run a CUDA binary to communicate with the GPU, ``caliban shell`` called a
+binary from the home directory rather than the one which the container should
+have used. This issue can be mitigated simply by using the ``--bare`` option,
+which will not mount the ``$HOME``  directory inside the container.

--- a/docs/cli/caliban_shell.rst
+++ b/docs/cli/caliban_shell.rst
@@ -85,10 +85,10 @@ prevent you from getting too far.
    the default, you can always pass the ``--shell`` argument, like this:
    ``caliban shell --shell bash``.
 
-One potential issue resulting from the fact that your home directory will mount
-into the container is that some binaries from your ``$HOME``  directory might
-leak into the container.  For example, we have seen a case in which, in trying
-to run a CUDA binary to communicate with the GPU, ``caliban shell`` called a
-binary from the home directory rather than the one which the container should
-have used. This issue can be mitigated simply by using the ``--bare`` option,
-which will not mount the ``$HOME``  directory inside the container.
+.. WARNING:: One potential issue resulting from the fact that your home directory will mount
+    into the container is that some binaries from your ``$HOME``  directory might
+    leak into the container.  For example, we have seen a case in which, in trying
+    to run a CUDA binary to communicate with the GPU, ``caliban shell`` called a
+    binary from the home directory rather than the one which the container should
+    have used. This issue can be mitigated simply by using the ``--bare`` option,
+    which will not mount the ``$HOME``  directory inside the container.


### PR DESCRIPTION
I made two improvements to the documentation.

1. I made CONTRIBUTING.md more transparent around the sphinx-reload, and 
2. I added a warning in the caliban shell section about a potential pitfall of the automatic mounting of the user's $HOME directory