### PR TITLE
[refs #00000] Allow editable installation of packages

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -93,3 +93,8 @@ RUN chmod -R 757 /opt/conda/envs/caliban && mkdir /.cache && chmod -R 757 /.cach
 
 # This is equivalent to activating the env.
 ENV PATH /opt/conda/envs/caliban/bin:$PATH
+
+# This makes pip recognize our conda environment
+# as a virtual environment, so it installs editables properly
+# See https://github.com/conda/conda/issues/5861 for details
+ENV PIP_SRC /opt/conda/envs/caliban/pipsrc


### PR DESCRIPTION
Because pip does not recognize conda environments as proper virtual
environments, prior to this fix whenever it tried to install a package
in editable mode (with the -e flag), it would put the package in the
current working directory.  This caused problems because that directory
was overwritten when using caliban shell.

We fix this by setting the environmental variable PIP_SRC to be
/opt/conda/envs/caliban/pipsrc.  This tells pip to install the package
in that directory.