### PR TITLE
Add new resource module, accessor function

### DIFF
--- a/caliban/resources/__init__.py
+++ b/caliban/resources/__init__.py
@@ -1,0 +1,15 @@
+#!/usr/bin/python
+#
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/caliban/util/__init__.py
+++ b/caliban/util/__init__.py
@@ -18,6 +18,7 @@ Utilities for our job runner.
 """
 import getpass
 import itertools as it
+import os
 import platform
 import sys
 from enum import Enum
@@ -25,6 +26,7 @@ from typing import (Any, Callable, Dict, Iterable, List, NamedTuple, Optional,
                     Set, Tuple, Union)
 
 from blessings import Terminal
+from pkg_resources import resource_filename
 
 t = Terminal()
 
@@ -55,6 +57,18 @@ def is_linux() -> bool:
 
   """
   return platform.system() == "Darwin"
+
+
+def resource(name: str) -> Optional[str]:
+  """If the supplied resource exists in caliban.resources, returns the absolute
+  path to the resource. Else, returns None.
+
+  """
+  path = resource_filename("caliban.resources", name)
+  if os.path.exists(path):
+    return path
+
+  return None
 
 
 def enum_vals(enum: Enum) -> List[str]:

--- a/tests/caliban/util/test_util.py
+++ b/tests/caliban/util/test_util.py
@@ -15,6 +15,9 @@
 # limitations under the License.
 
 import itertools
+import json
+import os
+import uuid
 from collections import OrderedDict
 from enum import Enum
 from typing import Union
@@ -41,6 +44,28 @@ def test_enum_vals(ks, vs):
 
   # enum_vals returns the values from the enum.
   assert list(m.values()) == u.enum_vals(enum)
+
+
+def test_resource_path():
+  resource_dir = u.resource("")
+  test_path = f"{uuid.uuid1()}.json"
+  full_path = os.path.join(resource_dir, test_path)
+
+  # Before writing any data, we get None back.
+  assert u.resource(test_path) is None
+
+  # Now write some data...
+  resource_data = {"apt_packages": ["face"]}
+  with open(full_path, 'w') as f:
+    json.dump(resource_data, f)
+
+  # now we see the full path.
+  assert u.resource(test_path) == full_path
+
+  os.remove(full_path)
+
+  # Just for fun, check that we've deleted it.
+  assert u.resource(test_path) is None
 
 
 def test_any_of_unit():


### PR DESCRIPTION
This PR adds a new module that contains resources Caliban may need to access during execution. The accessor handles the case where the resource doesn't yet exist by returning None.

(`resource_filename` by itself returns the path, even if the file doesn't exist. This is useful if you want to write a resource, but not for an accessor.)