### PR TITLE
Add a clearer COPY command for better reuse in `caliban.docker.build`

### DIFF
--- a/tests/caliban/docker/test_build.py
+++ b/tests/caliban/docker/test_build.py
@@ -21,3 +21,21 @@ def test_shell_dict():
   """Tests that the shell dict has an entry for all possible Shell values."""
 
   assert set(b.Shell) == set(b.SHELL_DICT.keys())
+
+
+def test_copy_command():
+  multiline = b.copy_command(1, 1, "face", "cake",
+                             "This is an example\nof a multiline comment.")
+
+  assert multiline == f"""# This is an example
+# of a multiline comment.
+COPY --chown=1:1 face cake"""
+
+  # single lines don't append comments.
+  oneline = b.copy_command(1, 1, "face", "cake.py")
+  assert oneline == "COPY --chown=1:1 face cake.py"
+
+  # single comments work.
+  oneline_comment = b.copy_command(1, 1, "face", "cake.py", comment="Comment!")
+  assert oneline_comment == f"""# Comment!
+COPY --chown=1:1 face cake.py"""


### PR DESCRIPTION
This PR adds a slightly clearer way of generating COPY commands inside a generated Dockerfile.

We also now have some slight tests here. I converted existing uses too, and reintroduced a few format strings.