### PR TITLE
Add caliban launcher script to enable mlflow [in progress]

### DIFF
--- a/caliban/resources/caliban_launcher.py
+++ b/caliban/resources/caliban_launcher.py
@@ -13,7 +13,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-'''caliban wrapper utility'''
+'''This utility wraps the caliban user's entrypoint in order to configure
+additional service processes and environment variables for each caliban
+job.
+'''
 
 import argparse
 import copy
@@ -23,6 +26,10 @@ import os
 import subprocess
 import sys
 import time
+
+RESOURCE_DIR = "/.resources"
+LAUNCHER_CONFIG_FILE = 'caliban_launcher_cfg.json'
+LAUNCHER_CONFIG_PATH = os.path.join(RESOURCE_DIR, LAUNCHER_CONFIG_FILE)
 
 logging.basicConfig(level=logging.INFO)
 
@@ -42,18 +49,16 @@ def _parse_json(argname, json_string, expected_type):
 
 
 def _parser():
-  '''generates argument parser'''
-
   parser = argparse.ArgumentParser(
-      description='caliban wrapper for container.',
-      prog='caliban_wrapper',
+      description='caliban launcher for container.',
+      prog='caliban_launcher',
       formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
   parser.add_argument(
-      '--caliban_env',
+      '--caliban_config',
       type=lambda x: _parse_json('env', x, dict),
       default={},
-      help='JSON dict of variables to set for container',
+      help='JSON config dictionary',
   )
 
   parser.add_argument(
@@ -62,30 +67,14 @@ def _parser():
       help='main container command to execute, as json list',
   )
 
-  parser.add_argument(
-      '--caliban_service',
-      type=lambda x: _parse_json('service', x, list),
-      action='append',
-      help=
-      'run the given command as a service prior to running the main entrypoint')
-
-  parser.add_argument(
-      '--caliban_delay',
-      type=int,
-      default=5,
-      help='delay in seconds between service executions',
-  )
-
   return parser
 
 
-# ----------------------------------------------------------------------------
 def _parse_flags(argv):
   return _parser().parse_known_args(argv[1:])
 
 
-# ----------------------------------------------------------------------------
-def _start_services(services, env, delay):
+def _start_services(services, env, delay=5):
   '''runs the commands in the services list, returns a list of Popen instances
   sets the environment variables in <env>, and delays by <delay> between
   commands
@@ -99,7 +88,6 @@ def _start_services(services, env, delay):
   return procs
 
 
-# ----------------------------------------------------------------------------
 def _execute_command(cmd, args, env):
   '''executes the given command with the provided args and env vars
   this blocks until the given command completes
@@ -110,14 +98,48 @@ def _execute_command(cmd, args, env):
   subprocess.check_call(cmd, env=env)
 
 
-# ----------------------------------------------------------------------------
+def _load_config_file():
+  '''loads the launcher configuration data from the config file
+  at ./resources/'caliban_laucher_cfg.json as a dict
+  '''
+  if not os.path.exists(LAUNCHER_CONFIG_PATH):
+    return {}
+
+  with open(LAUNCHER_CONFIG_PATH) as f:
+    cfg = json.load(f)
+
+  return cfg
+
+
+def _get_config(args):
+  '''gets the configuration dictionary for the launcher by combining the
+  static configuration in the launcher config file and the dynamic
+  configuration passed in the command args. Here the dynamic args take
+  precedence over static args where there is a collision.
+  '''
+
+  cfg = _load_config_file()
+  dynamic_config = args.caliban_config
+
+  for k, v in dynamic_config.items():
+    if k not in cfg:
+      cfg[k] = v
+    elif k == 'env':
+      cfg[k].update(v)
+    elif k == 'services':
+      cfg[k] += v
+
+  return cfg
+
+
 def main(args, passthrough_args):
 
+  config = _get_config(args)
+
   env = copy.copy(dict(os.environ))
-  caliban_env = args.caliban_env
+  caliban_env = config.get('env', {})
   cmd = args.caliban_command
-  services = args.caliban_service
-  delay = args.caliban_delay
+  services = config.get('services', [])
 
   logging.info('base env: %s' % str(env))
   logging.info('env vars: %s' % str(caliban_env))
@@ -127,13 +149,11 @@ def main(args, passthrough_args):
 
   env.update(caliban_env)
 
-  logging.info('dir:\n%s' % str(os.listdir()))
   logging.info('env:\n%s' % str(env))
 
-  _start_services(services, env, delay)
+  _start_services(services, env)
   _execute_command(cmd, passthrough_args, env)
 
 
-# ----------------------------------------------------------------------------
 if __name__ == '__main__':
   main(*_parse_flags(sys.argv))

--- a/caliban/resources/caliban_launcher.py
+++ b/caliban/resources/caliban_launcher.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python
+#
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+'''caliban wrapper utility'''
+
+import argparse
+import copy
+import json
+import logging
+import os
+import subprocess
+import sys
+import time
+
+logging.basicConfig(level=logging.INFO)
+
+
+def _parse_json(argname, json_string, expected_type):
+  """parses a json string, validating the return type"""
+
+  try:
+    obj = json.loads(json_string)
+    assert isinstance(obj, expected_type)
+  except Exception:
+    raise argparse.ArgumentTypeError(
+        "%s must be a json %s. Got '%s'." %
+        (argname, expected_type.__name__, json_string))
+
+  return obj
+
+
+def _parser():
+  '''generates argument parser'''
+
+  parser = argparse.ArgumentParser(
+      description='caliban wrapper for container.',
+      prog='caliban_wrapper',
+      formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+
+  parser.add_argument(
+      '--caliban_env',
+      type=lambda x: _parse_json('env', x, dict),
+      default={},
+      help='JSON dict of variables to set for container',
+  )
+
+  parser.add_argument(
+      '--caliban_command',
+      type=lambda x: _parse_json('command', x, list),
+      help='main container command to execute, as json list',
+  )
+
+  parser.add_argument(
+      '--caliban_service',
+      type=lambda x: _parse_json('service', x, list),
+      action='append',
+      help=
+      'run the given command as a service prior to running the main entrypoint')
+
+  parser.add_argument(
+      '--caliban_delay',
+      type=int,
+      default=5,
+      help='delay in seconds between service executions',
+  )
+
+  return parser
+
+
+# ----------------------------------------------------------------------------
+def _parse_flags(argv):
+  return _parser().parse_known_args(argv[1:])
+
+
+# ----------------------------------------------------------------------------
+def _start_services(services, env, delay):
+  '''runs the commands in the services list, returns a list of Popen instances
+  sets the environment variables in <env>, and delays by <delay> between
+  commands
+  '''
+  procs = []
+  for cmd in services:
+    logging.info(' '.join(cmd))
+    procs.append(subprocess.Popen(cmd, env=env))
+    time.sleep(delay)
+
+  return procs
+
+
+# ----------------------------------------------------------------------------
+def _execute_command(cmd, args, env):
+  '''executes the given command with the provided args and env vars
+  this blocks until the given command completes
+  '''
+
+  cmd = cmd + args
+  logging.info(' '.join(cmd))
+  subprocess.check_call(cmd, env=env)
+
+
+# ----------------------------------------------------------------------------
+def main(args, passthrough_args):
+
+  env = copy.copy(dict(os.environ))
+  caliban_env = args.caliban_env
+  cmd = args.caliban_command
+  services = args.caliban_service
+  delay = args.caliban_delay
+
+  logging.info('base env: %s' % str(env))
+  logging.info('env vars: %s' % str(caliban_env))
+  logging.info('command: %s' % ' '.join([str(x) for x in cmd]))
+  logging.info('passthrough args: %s' % str(passthrough_args))
+  logging.info('caliban services: %s' % str(services))
+
+  env.update(caliban_env)
+
+  logging.info('dir:\n%s' % str(os.listdir()))
+  logging.info('env:\n%s' % str(env))
+
+  _start_services(services, env, delay)
+  _execute_command(cmd, passthrough_args, env)
+
+
+# ----------------------------------------------------------------------------
+if __name__ == '__main__':
+  main(*_parse_flags(sys.argv))

--- a/caliban/util/metrics.py
+++ b/caliban/util/metrics.py
@@ -22,6 +22,7 @@ configuring a container for this behavior.
 import caliban.util as u
 
 CLOUD_SQL_WRAPPER_SCRIPT = 'cloud_sql_proxy.py'
+LAUNCHER_SCRIPT = 'caliban_launcher.py'
 
 
 def cloud_sql_proxy_path() -> str:
@@ -30,3 +31,11 @@ def cloud_sql_proxy_path() -> str:
 
   """
   return u.resource(CLOUD_SQL_WRAPPER_SCRIPT)
+
+
+def launcher_path() -> str:
+  """Returns an absolute path to the Caliban python wrapper that manages
+environment variable setting and service launches inside the container.
+
+  """
+  return u.resource(LAUNCHER_SCRIPT)

--- a/caliban/util/metrics.py
+++ b/caliban/util/metrics.py
@@ -40,7 +40,7 @@ DOCKER_IMAGE_TAG = 'docker_image'
 PLATFORM_TAG = 'platform'
 
 
-def cloud_sql_proxy_path() -> str:
+def cloud_sql_proxy_path() -> Optional[str]:
   """Returns an absolute path to the cloud_sql_proxy python wrapper that we
   inject into containers.
 
@@ -48,7 +48,7 @@ def cloud_sql_proxy_path() -> str:
   return u.resource(CLOUD_SQL_WRAPPER_SCRIPT)
 
 
-def launcher_path() -> str:
+def launcher_path() -> Optional[str]:
   """Returns an absolute path to the caliban_launcher python script that we
   inject into containers.
 
@@ -136,6 +136,8 @@ def launcher_config_file(
   Yields:
   path to configuration file
   '''
+
+  caliban_config = caliban_config or {}
 
   config = _default_launcher_config()
   config_file_path = os.path.join(path, LAUNCHER_CONFIG_FILE)

--- a/caliban/util/metrics.py
+++ b/caliban/util/metrics.py
@@ -19,10 +19,25 @@ configuring a container for this behavior.
 
 """
 
+import datetime
+import json
+import os
+
 import caliban.util as u
+import caliban.history.types as ht
+from contextlib import contextmanager
+from typing import Dict, Any, List, Optional
 
 CLOUD_SQL_WRAPPER_SCRIPT = 'cloud_sql_proxy.py'
 LAUNCHER_SCRIPT = 'caliban_launcher.py'
+RESOURCE_DIR = "/.resources"
+LAUNCHER_CONFIG_FILE = 'caliban_launcher_cfg.json'
+LAUNCHER_CONFIG_PATH = os.path.join(RESOURCE_DIR, LAUNCHER_CONFIG_FILE)
+GPU_ENABLED_TAG = 'gpu_enabled'
+TPU_ENABLED_TAG = 'tpu_enabled'
+JOB_NAME_TAG = 'job_name'
+DOCKER_IMAGE_TAG = 'docker_image'
+PLATFORM_TAG = 'platform'
 
 
 def cloud_sql_proxy_path() -> str:
@@ -34,8 +49,136 @@ def cloud_sql_proxy_path() -> str:
 
 
 def launcher_path() -> str:
-  """Returns an absolute path to the Caliban python wrapper that manages
-environment variable setting and service launches inside the container.
+  """Returns an absolute path to the caliban_launcher python script that we
+  inject into containers.
 
   """
   return u.resource(LAUNCHER_SCRIPT)
+
+
+def _default_launcher_config() -> Dict[str, Any]:
+  return {
+      'services': [],
+      'env': {},
+  }
+
+
+def _create_mlflow_config(
+    cfg: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+  '''generates mlflow configuration dict for launcher script
+  Args:
+  cfg: mlflow configuration dict from .calibanconfig.json
+
+  Returns:
+  config dict for launcher script with entries needed for mlflow
+  '''
+
+  if cfg is None:
+    return _default_launcher_config()
+
+  user = cfg['user']
+  pw = cfg['password']
+  db = cfg['db']
+  project = cfg['project']
+  region = cfg['region']
+  artifact_root = cfg['artifact_root']
+
+  socket_path = '/tmp/cloudsql'
+  proxy_path = os.path.join(os.sep, 'usr', 'bin', 'cloud_sql_proxy')
+
+  proxy_config = json.dumps({
+      'proxy': proxy_path,
+      'path': socket_path,
+      'project': project,
+      'region': region,
+      'db': db,
+      'creds': '~/.config/gcloud/application_default_credentials.json',
+  })
+
+  proxy_cmd = [
+      'python',
+      os.path.join(RESOURCE_DIR, CLOUD_SQL_WRAPPER_SCRIPT), proxy_config
+  ]
+
+  tracking_uri = (
+      f'postgresql+pg8000://{user}:{pw}@/{db}?unix_sock={socket_path}/'
+      f'{project}:{region}:{db}/.s.PGSQL.5432')
+
+  return {
+      'services': [proxy_cmd],
+      'env': {
+          'MLFLOW_TRACKING_URI': tracking_uri,
+          'MLFLOW_ARTIFACT_ROOT': artifact_root
+      }
+  }
+
+
+@contextmanager
+def launcher_config_file(
+    path: str,
+    caliban_config: Optional[Dict[str, Any]] = None,
+):
+  '''creates a configuration file for the caliban launcher script
+  This file contains the launcher configuration that does not vary across
+  each caliban job being submitted, so it can be copied into the container.
+
+  This is to be used as a contextmanager yielding the path to the file:
+
+  with launcher_config_file('.', caliban_config) as cfg_file:
+    # do things
+
+  The config file is deleted upon exiting the context scope.
+
+  Args:
+  path: directory in which to write file (this must exist)
+  caliban_config: caliban configuration dictionary
+
+  Yields:
+  path to configuration file
+  '''
+
+  config = _default_launcher_config()
+  config_file_path = os.path.join(path, LAUNCHER_CONFIG_FILE)
+
+  mlflow_config = _create_mlflow_config(caliban_config.get('mlflow_config'))
+
+  config['services'] += mlflow_config['services']
+  config['env'].update(mlflow_config['env'])
+
+  with open(config_file_path, 'w') as f:
+    json.dump(config, f, indent=2)
+
+  try:
+    yield config_file_path
+  finally:
+    if os.path.exists(config_file_path):
+      os.remove(config_file_path)
+
+
+def _mlflow_job_name(index: int, user: str = None) -> str:
+  user = user or u.current_user()
+  timestamp = datetime.datetime.now().strftime('%Y-%m-%d-%H-%M-%S')
+  return f'{user}-{timestamp}-{index}'
+
+
+def mlflow_args(
+    experiment_name: str,
+    index: int,
+    tags: Dict[str, Any],
+) -> List[str]:
+  '''returns mlflow args for caliban launcher
+  Args:
+
+  experiment: experiment object
+  index: job index
+  tags: dictionary of tags to pass to mlflow
+
+  Returns:
+  mlflow args list
+  '''
+
+  env = {f'ENVVAR_{k}': v for k, v in tags.items()}
+  env['MLFLOW_EXPERIMENT_NAME'] = experiment_name
+  env['MLFLOW_RUN_NAME'] = _mlflow_job_name(index=index)
+
+  return ['--caliban_config', json.dumps({'env': env})]

--- a/tests/caliban/util/test_metrics.py
+++ b/tests/caliban/util/test_metrics.py
@@ -14,7 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import os
+import tempfile
 
 import caliban.util as u
 import caliban.util.metrics as um
@@ -36,3 +38,149 @@ def test_launcher_path():
   # check that the name matches the global variable.
   expected = os.path.join(u.resource(""), um.LAUNCHER_SCRIPT)
   assert um.launcher_path() == expected
+
+
+def test_mlflow_args():
+  '''verifies that we generate the dynamic args for the caliban launcher
+  script for mlflow integration'''
+
+  cfg = {
+      'experiment_name': 'foo',
+      'index': 42,
+      'tags': {
+          'a': 'x',
+          'b': 7
+      },
+  }
+
+  mlflow_args = um.mlflow_args(**cfg)
+
+  assert len(mlflow_args) == 2
+  assert mlflow_args[0] == '--caliban_config'
+
+  # make sure that config is json dict
+  arg_dict = json.loads(mlflow_args[1])
+  assert isinstance(arg_dict, dict)
+
+  assert 'env' in arg_dict
+  env_vars = arg_dict['env']
+  assert 'MLFLOW_EXPERIMENT_NAME' in env_vars
+  assert env_vars['MLFLOW_EXPERIMENT_NAME'] == cfg['experiment_name']
+
+  assert 'MLFLOW_RUN_NAME' in env_vars
+  assert isinstance(env_vars['MLFLOW_RUN_NAME'], str)
+
+  for k, v in cfg['tags'].items():
+    k_e = f'ENVVAR_{k}'
+    assert k_e in env_vars
+    assert env_vars[k_e] == v
+
+
+def test_launcher_config_file():
+  '''verifies that we generate the static caliban launcher config file
+  properly for different scenarios'''
+
+  # test config file without mlflow
+  with tempfile.TemporaryDirectory() as tmpdir:
+    cfg = {
+        'path': tmpdir,
+        'caliban_config': {
+            'base_image': 'gcr.io/blueshift-playground/blueshift:cpu',
+            'apt_packages': ['curl'],
+        },
+    }
+
+    cfg_fname = ''
+    with um.launcher_config_file(**cfg) as fname:
+      cfg_fname = fname
+      assert fname is not None
+      assert os.path.exists(fname)
+      assert fname == os.path.join(tmpdir, um.LAUNCHER_CONFIG_FILE)
+
+      with open(fname, 'r') as f:
+        lcfg = json.load(f)
+
+      assert isinstance(lcfg, dict)
+      assert 'services' in lcfg
+      assert 'env' in lcfg
+      services = lcfg['services']
+      env = lcfg['env']
+      assert isinstance(services, list)
+      assert isinstance(env, dict)
+      assert len(services) == 0
+
+    # make sure we clean up
+    assert not os.path.exists(cfg_fname)
+
+  # test config file with mlflow
+  with tempfile.TemporaryDirectory() as tmpdir:
+
+    project = 'foo-project'
+    region = 'foo-region'
+    db = 'foo-db'
+    user = 'foo-user'
+    password = 'foo-password'
+    artifact_root = 'foo-artifact-root'
+
+    cfg = {
+        'path': tmpdir,
+        'caliban_config': {
+            'base_image': 'gcr.io/blueshift-playground/blueshift:cpu',
+            'apt_packages': ['curl'],
+            'mlflow_config': {
+                'project': project,
+                'region': region,
+                'db': db,
+                'user': user,
+                'password': password,
+                'artifact_root': artifact_root,
+            },
+        },
+    }
+
+    proxy_config = {
+        'proxy': os.path.join(os.sep, 'usr', 'bin', 'cloud_sql_proxy'),
+        'path': '/tmp/cloudsql',
+        'project': project,
+        'region': region,
+        'db': db,
+        'creds': '~/.config/gcloud/application_default_credentials.json',
+    }
+
+    proxy_cmd = [
+        'python',
+        os.path.join(um.RESOURCE_DIR, um.CLOUD_SQL_WRAPPER_SCRIPT),
+        proxy_config,
+    ]
+
+    cfg_fname = ''
+    with um.launcher_config_file(**cfg) as fname:
+      cfg_fname == fname
+      assert fname is not None
+      assert os.path.exists(fname)
+      assert fname == os.path.join(tmpdir, um.LAUNCHER_CONFIG_FILE)
+
+      with open(fname, 'r') as f:
+        lcfg = json.load(f)
+
+      assert isinstance(lcfg, dict)
+      assert 'services' in lcfg
+      assert 'env' in lcfg
+
+      services = lcfg['services']
+      env = lcfg['env']
+
+      assert isinstance(services, list)
+      assert isinstance(env, dict)
+      assert len(services) == 1
+
+      cfg_proxy_cmd = services[0]
+      assert cfg_proxy_cmd[0] == proxy_cmd[0]
+      assert cfg_proxy_cmd[1] == proxy_cmd[1]
+      cfg_proxy_config = proxy_cmd[2]
+      for k, v in proxy_config.items():
+        assert k in cfg_proxy_config
+        assert cfg_proxy_config[k] == v
+
+    # make sure we clean up appropriately
+    assert not os.path.exists(cfg_fname)

--- a/tests/caliban/util/test_metrics.py
+++ b/tests/caliban/util/test_metrics.py
@@ -27,3 +27,12 @@ def test_cloud_sql_proxy_path():
   # check that the name matches the global variable.
   expected = os.path.join(u.resource(""), um.CLOUD_SQL_WRAPPER_SCRIPT)
   assert um.cloud_sql_proxy_path() == expected
+
+
+def test_launcher_path():
+  """Check that the launcher resource exists and wasn't deleted or renamed."""
+  assert um.launcher_path() is not None
+
+  # check that the name matches the global variable.
+  expected = os.path.join(u.resource(""), um.LAUNCHER_SCRIPT)
+  assert um.launcher_path() == expected


### PR DESCRIPTION
This (in progress) PR:

- adds the ability to inject a launcher script into the container, with the ability to intercept arguments, set environment variables and start up a service that will be available for the duration of the container's task.

This is the conclusion of a port of #35 .