### PR TITLE
fix for issue 68: adds newline in COPY directives generated by the copy_command method

### DIFF
--- a/caliban/docker/build.py
+++ b/caliban/docker/build.py
@@ -119,7 +119,7 @@ def copy_command(user_id: int,
   recommend using an absolute path!
 
   """
-  cmd = f"COPY --chown={user_id}:{user_group} {from_path} {to_path}"
+  cmd = f"COPY --chown={user_id}:{user_group} {from_path} {to_path}\n"
 
   if comment is not None:
     comment_s = "\n# ".join(comment.split("\n"))

--- a/tests/caliban/docker/test_build.py
+++ b/tests/caliban/docker/test_build.py
@@ -29,13 +29,16 @@ def test_copy_command():
 
   assert multiline == f"""# This is an example
 # of a multiline comment.
-COPY --chown=1:1 face cake"""
+COPY --chown=1:1 face cake
+"""
 
   # single lines don't append comments.
   oneline = b.copy_command(1, 1, "face", "cake.py")
-  assert oneline == "COPY --chown=1:1 face cake.py"
+  assert oneline == """COPY --chown=1:1 face cake.py
+"""
 
   # single comments work.
   oneline_comment = b.copy_command(1, 1, "face", "cake.py", comment="Comment!")
   assert oneline_comment == f"""# Comment!
-COPY --chown=1:1 face cake.py"""
+COPY --chown=1:1 face cake.py
+"""


### PR DESCRIPTION
This addresses issue #68, adding a newline to the end of `COPY` dockerfile directives generated by the `copy_command()` method in `build.py`. Thanks to @eschnett for finding this and the appropriate fix.