### PR TITLE
This PR adds mypy directives to setup.cfg to suppress third-party library warnings

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,3 +23,36 @@ style = pep440
 versionfile_source = caliban/_version.py
 versionfile_build = caliban/_version.py
 tag_prefix =
+
+[mypy-tqdm.*]
+ignore_missing_imports = True
+
+[mypy-absl.*]
+ignore_missing_imports = True
+
+[mypy-blessings.*]
+ignore_missing_imports = True
+
+[mypy-googleapiclient.*]
+ignore_missing_imports = True
+
+[mypy-sqlalchemy.*]
+ignore_missing_imports = True
+
+[mypy-kubernetes.*]
+ignore_missing_imports = True
+
+[mypy-google.*]
+ignore_missing_imports = True
+
+[mypy-urllib3.*]
+ignore_missing_imports = True
+
+[mypy-yaspin.*]
+ignore_missing_imports = True
+
+[mypy-schema.*]
+ignore_missing_imports = True
+
+[mypy-commentjson.*]
+ignore_missing_imports = True


### PR DESCRIPTION
This PR just adds some `mypy` entries to `setup.cfg` to suppress warnings for third-party packages.
See https://mypy.readthedocs.io/en/stable/config_file.html?highlight=setup.cfg#the-mypy-configuration-file