### PR TITLE
Add ubuntu base image support to cloudbuild, add ubuntu 20.04 cpu base image

### DIFF
--- a/cloudbuild.json
+++ b/cloudbuild.json
@@ -1,16 +1,18 @@
 {
   "steps": [
     {
-      "id": "gcr.io/blueshift-playground/cloudbuild_test:gpu-base-cuda100",
+      "id": "gcr.io/blueshift-playground/blueshift:gpu-base-ubuntu1804-cuda100",
       "name": "gcr.io/cloud-builders/docker",
       "args": [
         "build",
         "-t",
-        "gcr.io/blueshift-playground/cloudbuild_test:gpu-base-cuda100",
+        "gcr.io/blueshift-playground/blueshift:gpu-base-ubuntu1804-cuda100",
         "-f",
         "dockerfiles/Dockerfile.gpu",
         "--build-arg",
         "CUDA=10.0",
+        "--build-arg",
+        "UBUNTU_VERSION=18.04",
         "."
       ],
       "waitFor": [
@@ -18,27 +20,29 @@
       ]
     },
     {
-      "id": "gcr.io/blueshift-playground/cloudbuild_test:gpu-base-cuda100-push",
+      "id": "gcr.io/blueshift-playground/blueshift:gpu-base-ubuntu1804-cuda100-push",
       "name": "gcr.io/cloud-builders/docker",
       "args": [
         "push",
-        "gcr.io/blueshift-playground/cloudbuild_test:gpu-base-cuda100"
+        "gcr.io/blueshift-playground/blueshift:gpu-base-ubuntu1804-cuda100"
       ],
       "waitFor": [
-        "gcr.io/blueshift-playground/cloudbuild_test:gpu-base-cuda100"
+        "gcr.io/blueshift-playground/blueshift:gpu-base-ubuntu1804-cuda100"
       ]
     },
     {
-      "id": "gcr.io/blueshift-playground/cloudbuild_test:gpu-base-cuda101",
+      "id": "gcr.io/blueshift-playground/blueshift:gpu-base-ubuntu1804-cuda101",
       "name": "gcr.io/cloud-builders/docker",
       "args": [
         "build",
         "-t",
-        "gcr.io/blueshift-playground/cloudbuild_test:gpu-base-cuda101",
+        "gcr.io/blueshift-playground/blueshift:gpu-base-ubuntu1804-cuda101",
         "-f",
         "dockerfiles/Dockerfile.gpu",
         "--build-arg",
         "CUDA=10.1",
+        "--build-arg",
+        "UBUNTU_VERSION=18.04",
         "."
       ],
       "waitFor": [
@@ -46,31 +50,31 @@
       ]
     },
     {
-      "id": "gcr.io/blueshift-playground/cloudbuild_test:gpu-base-cuda101-push",
+      "id": "gcr.io/blueshift-playground/blueshift:gpu-base-ubuntu1804-cuda101-push",
       "name": "gcr.io/cloud-builders/docker",
       "args": [
         "push",
-        "gcr.io/blueshift-playground/cloudbuild_test:gpu-base-cuda101"
+        "gcr.io/blueshift-playground/blueshift:gpu-base-ubuntu1804-cuda101"
       ],
       "waitFor": [
-        "gcr.io/blueshift-playground/cloudbuild_test:gpu-base-cuda101"
+        "gcr.io/blueshift-playground/blueshift:gpu-base-ubuntu1804-cuda101"
       ]
     },
     {
-      "id": "gcr.io/blueshift-playground/cloudbuild_test:cpu-py37",
+      "id": "gcr.io/blueshift-playground/blueshift:cpu-ubuntu1804-py37",
       "name": "gcr.io/cloud-builders/docker",
       "args": [
         "build",
         "-t",
-        "gcr.io/blueshift-playground/cloudbuild_test:cpu-py37",
+        "gcr.io/blueshift-playground/blueshift:cpu-ubuntu1804-py37",
         "-f",
         "dockerfiles/Dockerfile",
+        "--build-arg",
+        "PYTHON_VERSION=3.7",
+        "--build-arg",
+        "MINICONDA_VERSION=py37_4.8.2",
         "--build-arg",
         "BASE_IMAGE=ubuntu:18.04",
-        "--build-arg",
-        "PYTHON_VERSION=3.7",
-        "--build-arg",
-        "MINICONDA_VERSION=py37_4.8.2",
         "."
       ],
       "waitFor": [
@@ -78,31 +82,31 @@
       ]
     },
     {
-      "id": "gcr.io/blueshift-playground/cloudbuild_test:cpu-py37-push",
+      "id": "gcr.io/blueshift-playground/blueshift:cpu-ubuntu1804-py37-push",
       "name": "gcr.io/cloud-builders/docker",
       "args": [
         "push",
-        "gcr.io/blueshift-playground/cloudbuild_test:cpu-py37"
+        "gcr.io/blueshift-playground/blueshift:cpu-ubuntu1804-py37"
       ],
       "waitFor": [
-        "gcr.io/blueshift-playground/cloudbuild_test:cpu-py37"
+        "gcr.io/blueshift-playground/blueshift:cpu-ubuntu1804-py37"
       ]
     },
     {
-      "id": "gcr.io/blueshift-playground/cloudbuild_test:cpu-py38",
+      "id": "gcr.io/blueshift-playground/blueshift:cpu-ubuntu1804-py38",
       "name": "gcr.io/cloud-builders/docker",
       "args": [
         "build",
         "-t",
-        "gcr.io/blueshift-playground/cloudbuild_test:cpu-py38",
+        "gcr.io/blueshift-playground/blueshift:cpu-ubuntu1804-py38",
         "-f",
         "dockerfiles/Dockerfile",
+        "--build-arg",
+        "PYTHON_VERSION=3.8",
+        "--build-arg",
+        "MINICONDA_VERSION=py38_4.8.2",
         "--build-arg",
         "BASE_IMAGE=ubuntu:18.04",
-        "--build-arg",
-        "PYTHON_VERSION=3.8",
-        "--build-arg",
-        "MINICONDA_VERSION=py38_4.8.2",
         "."
       ],
       "waitFor": [
@@ -110,142 +114,206 @@
       ]
     },
     {
-      "id": "gcr.io/blueshift-playground/cloudbuild_test:cpu-py38-push",
+      "id": "gcr.io/blueshift-playground/blueshift:cpu-ubuntu1804-py38-push",
       "name": "gcr.io/cloud-builders/docker",
       "args": [
         "push",
-        "gcr.io/blueshift-playground/cloudbuild_test:cpu-py38"
+        "gcr.io/blueshift-playground/blueshift:cpu-ubuntu1804-py38"
       ],
       "waitFor": [
-        "gcr.io/blueshift-playground/cloudbuild_test:cpu-py38"
+        "gcr.io/blueshift-playground/blueshift:cpu-ubuntu1804-py38"
       ]
     },
     {
-      "id": "gcr.io/blueshift-playground/cloudbuild_test:gpu-cuda100-py37",
+      "id": "gcr.io/blueshift-playground/blueshift:gpu-ubuntu1804-py37-cuda100",
       "name": "gcr.io/cloud-builders/docker",
       "args": [
         "build",
         "-t",
-        "gcr.io/blueshift-playground/cloudbuild_test:gpu-cuda100-py37",
+        "gcr.io/blueshift-playground/blueshift:gpu-ubuntu1804-py37-cuda100",
         "-f",
         "dockerfiles/Dockerfile",
-        "--build-arg",
-        "BASE_IMAGE=gcr.io/blueshift-playground/cloudbuild_test:gpu-base-cuda100",
         "--build-arg",
         "PYTHON_VERSION=3.7",
         "--build-arg",
         "MINICONDA_VERSION=py37_4.8.2",
+        "--build-arg",
+        "BASE_IMAGE=gcr.io/blueshift-playground/blueshift:gpu-base-ubuntu1804-cuda100",
         "."
       ],
       "waitFor": [
-        "gcr.io/blueshift-playground/cloudbuild_test:gpu-base-cuda100"
+        "gcr.io/blueshift-playground/blueshift:gpu-base-ubuntu1804-cuda100"
       ]
     },
     {
-      "id": "gcr.io/blueshift-playground/cloudbuild_test:gpu-cuda100-py37-push",
+      "id": "gcr.io/blueshift-playground/blueshift:gpu-ubuntu1804-py37-cuda100-push",
       "name": "gcr.io/cloud-builders/docker",
       "args": [
         "push",
-        "gcr.io/blueshift-playground/cloudbuild_test:gpu-cuda100-py37"
+        "gcr.io/blueshift-playground/blueshift:gpu-ubuntu1804-py37-cuda100"
       ],
       "waitFor": [
-        "gcr.io/blueshift-playground/cloudbuild_test:gpu-cuda100-py37"
+        "gcr.io/blueshift-playground/blueshift:gpu-ubuntu1804-py37-cuda100"
       ]
     },
     {
-      "id": "gcr.io/blueshift-playground/cloudbuild_test:gpu-cuda101-py37",
+      "id": "gcr.io/blueshift-playground/blueshift:gpu-ubuntu1804-py37-cuda101",
       "name": "gcr.io/cloud-builders/docker",
       "args": [
         "build",
         "-t",
-        "gcr.io/blueshift-playground/cloudbuild_test:gpu-cuda101-py37",
+        "gcr.io/blueshift-playground/blueshift:gpu-ubuntu1804-py37-cuda101",
         "-f",
         "dockerfiles/Dockerfile",
-        "--build-arg",
-        "BASE_IMAGE=gcr.io/blueshift-playground/cloudbuild_test:gpu-base-cuda101",
         "--build-arg",
         "PYTHON_VERSION=3.7",
         "--build-arg",
         "MINICONDA_VERSION=py37_4.8.2",
+        "--build-arg",
+        "BASE_IMAGE=gcr.io/blueshift-playground/blueshift:gpu-base-ubuntu1804-cuda101",
         "."
       ],
       "waitFor": [
-        "gcr.io/blueshift-playground/cloudbuild_test:gpu-base-cuda101"
+        "gcr.io/blueshift-playground/blueshift:gpu-base-ubuntu1804-cuda101"
       ]
     },
     {
-      "id": "gcr.io/blueshift-playground/cloudbuild_test:gpu-cuda101-py37-push",
+      "id": "gcr.io/blueshift-playground/blueshift:gpu-ubuntu1804-py37-cuda101-push",
       "name": "gcr.io/cloud-builders/docker",
       "args": [
         "push",
-        "gcr.io/blueshift-playground/cloudbuild_test:gpu-cuda101-py37"
+        "gcr.io/blueshift-playground/blueshift:gpu-ubuntu1804-py37-cuda101"
       ],
       "waitFor": [
-        "gcr.io/blueshift-playground/cloudbuild_test:gpu-cuda101-py37"
+        "gcr.io/blueshift-playground/blueshift:gpu-ubuntu1804-py37-cuda101"
       ]
     },
     {
-      "id": "gcr.io/blueshift-playground/cloudbuild_test:gpu-cuda100-py38",
+      "id": "gcr.io/blueshift-playground/blueshift:gpu-ubuntu1804-py38-cuda100",
       "name": "gcr.io/cloud-builders/docker",
       "args": [
         "build",
         "-t",
-        "gcr.io/blueshift-playground/cloudbuild_test:gpu-cuda100-py38",
+        "gcr.io/blueshift-playground/blueshift:gpu-ubuntu1804-py38-cuda100",
         "-f",
         "dockerfiles/Dockerfile",
-        "--build-arg",
-        "BASE_IMAGE=gcr.io/blueshift-playground/cloudbuild_test:gpu-base-cuda100",
         "--build-arg",
         "PYTHON_VERSION=3.8",
         "--build-arg",
         "MINICONDA_VERSION=py38_4.8.2",
+        "--build-arg",
+        "BASE_IMAGE=gcr.io/blueshift-playground/blueshift:gpu-base-ubuntu1804-cuda100",
         "."
       ],
       "waitFor": [
-        "gcr.io/blueshift-playground/cloudbuild_test:gpu-base-cuda100"
+        "gcr.io/blueshift-playground/blueshift:gpu-base-ubuntu1804-cuda100"
       ]
     },
     {
-      "id": "gcr.io/blueshift-playground/cloudbuild_test:gpu-cuda100-py38-push",
+      "id": "gcr.io/blueshift-playground/blueshift:gpu-ubuntu1804-py38-cuda100-push",
       "name": "gcr.io/cloud-builders/docker",
       "args": [
         "push",
-        "gcr.io/blueshift-playground/cloudbuild_test:gpu-cuda100-py38"
+        "gcr.io/blueshift-playground/blueshift:gpu-ubuntu1804-py38-cuda100"
       ],
       "waitFor": [
-        "gcr.io/blueshift-playground/cloudbuild_test:gpu-cuda100-py38"
+        "gcr.io/blueshift-playground/blueshift:gpu-ubuntu1804-py38-cuda100"
       ]
     },
     {
-      "id": "gcr.io/blueshift-playground/cloudbuild_test:gpu-cuda101-py38",
+      "id": "gcr.io/blueshift-playground/blueshift:gpu-ubuntu1804-py38-cuda101",
       "name": "gcr.io/cloud-builders/docker",
       "args": [
         "build",
         "-t",
-        "gcr.io/blueshift-playground/cloudbuild_test:gpu-cuda101-py38",
+        "gcr.io/blueshift-playground/blueshift:gpu-ubuntu1804-py38-cuda101",
         "-f",
         "dockerfiles/Dockerfile",
-        "--build-arg",
-        "BASE_IMAGE=gcr.io/blueshift-playground/cloudbuild_test:gpu-base-cuda101",
         "--build-arg",
         "PYTHON_VERSION=3.8",
         "--build-arg",
         "MINICONDA_VERSION=py38_4.8.2",
+        "--build-arg",
+        "BASE_IMAGE=gcr.io/blueshift-playground/blueshift:gpu-base-ubuntu1804-cuda101",
         "."
       ],
       "waitFor": [
-        "gcr.io/blueshift-playground/cloudbuild_test:gpu-base-cuda101"
+        "gcr.io/blueshift-playground/blueshift:gpu-base-ubuntu1804-cuda101"
       ]
     },
     {
-      "id": "gcr.io/blueshift-playground/cloudbuild_test:gpu-cuda101-py38-push",
+      "id": "gcr.io/blueshift-playground/blueshift:gpu-ubuntu1804-py38-cuda101-push",
       "name": "gcr.io/cloud-builders/docker",
       "args": [
         "push",
-        "gcr.io/blueshift-playground/cloudbuild_test:gpu-cuda101-py38"
+        "gcr.io/blueshift-playground/blueshift:gpu-ubuntu1804-py38-cuda101"
       ],
       "waitFor": [
-        "gcr.io/blueshift-playground/cloudbuild_test:gpu-cuda101-py38"
+        "gcr.io/blueshift-playground/blueshift:gpu-ubuntu1804-py38-cuda101"
+      ]
+    },
+    {
+      "id": "gcr.io/blueshift-playground/blueshift:cpu-ubuntu2004-py37",
+      "name": "gcr.io/cloud-builders/docker",
+      "args": [
+        "build",
+        "-t",
+        "gcr.io/blueshift-playground/blueshift:cpu-ubuntu2004-py37",
+        "-f",
+        "dockerfiles/Dockerfile",
+        "--build-arg",
+        "PYTHON_VERSION=3.7",
+        "--build-arg",
+        "MINICONDA_VERSION=py37_4.8.2",
+        "--build-arg",
+        "BASE_IMAGE=ubuntu:20.04",
+        "."
+      ],
+      "waitFor": [
+        "-"
+      ]
+    },
+    {
+      "id": "gcr.io/blueshift-playground/blueshift:cpu-ubuntu2004-py37-push",
+      "name": "gcr.io/cloud-builders/docker",
+      "args": [
+        "push",
+        "gcr.io/blueshift-playground/blueshift:cpu-ubuntu2004-py37"
+      ],
+      "waitFor": [
+        "gcr.io/blueshift-playground/blueshift:cpu-ubuntu2004-py37"
+      ]
+    },
+    {
+      "id": "gcr.io/blueshift-playground/blueshift:cpu-ubuntu2004-py38",
+      "name": "gcr.io/cloud-builders/docker",
+      "args": [
+        "build",
+        "-t",
+        "gcr.io/blueshift-playground/blueshift:cpu-ubuntu2004-py38",
+        "-f",
+        "dockerfiles/Dockerfile",
+        "--build-arg",
+        "PYTHON_VERSION=3.8",
+        "--build-arg",
+        "MINICONDA_VERSION=py38_4.8.2",
+        "--build-arg",
+        "BASE_IMAGE=ubuntu:20.04",
+        "."
+      ],
+      "waitFor": [
+        "-"
+      ]
+    },
+    {
+      "id": "gcr.io/blueshift-playground/blueshift:cpu-ubuntu2004-py38-push",
+      "name": "gcr.io/cloud-builders/docker",
+      "args": [
+        "push",
+        "gcr.io/blueshift-playground/blueshift:cpu-ubuntu2004-py38"
+      ],
+      "waitFor": [
+        "gcr.io/blueshift-playground/blueshift:cpu-ubuntu2004-py38"
       ]
     }
   ],

--- a/docs/explore/base_image.rst
+++ b/docs/explore/base_image.rst
@@ -84,7 +84,7 @@ command:
 
 .. code-block:: bash
 
-   gcloud builds submit .
+   gcloud builds submit --project=<destination project> --config=cloudbuild.json .
 
 By default this uses your default project and the ``cloudbuild.json`` file in your current
 directory. If you are pushing the images to a different project than your ``gcloud`` default,

--- a/scripts/cloudbuild.py
+++ b/scripts/cloudbuild.py
@@ -2,7 +2,8 @@
 '''creates cloudbuild.json for caliban'''
 
 from absl import flags, app, logging
-from typing import Dict, List, Any, NamedTuple, Optional
+from copy import copy
+from typing import Dict, List, Any, NamedTuple, Optional, Set
 from enum import Enum
 
 import json
@@ -57,13 +58,31 @@ class ImageType(Enum):
   GPU = 'GPU'
 
 
+class GpuBase(NamedTuple):
+  base_image: str
+  gpu: str
+
+  @property
+  def tag(self) -> str:
+    return f'{self.base_image}-{self.gpu}'
+
+
+class CpuBase(NamedTuple):
+  base_image: str
+  python: str
+
+  @property
+  def tag(self) -> str:
+    return f'{self.base_image}-{self.python}'
+
+
 class ImageSpec(NamedTuple):
   '''a caliban base image spec'''
   dockerfile: str = _CPU_DOCKERFILE
   base_image: Optional[str] = _CPU_BASE_IMAGE
   cpu_version: Optional[str] = None
   gpu_version: Optional[str] = None
-  build_args: List[str] = []
+  build_args: Dict[str, str] = {}
 
   @property
   def image_type(self) -> ImageType:
@@ -79,13 +98,13 @@ class ImageSpec(NamedTuple):
   def tag(self) -> str:
     parts = []
     if self.image_type == ImageType.CPU:
-      parts = [_CPU_TAG, self.cpu_version]
+      parts = [_CPU_TAG, self.base_image, self.cpu_version]
     else:
       parts.append(_GPU_TAG)
       if self.image_type == ImageType.GPU_BASE:
-        parts += ['base', self.gpu_version]
+        parts += ['base', self.base_image, self.gpu_version]
       else:
-        parts += [self.gpu_version, self.cpu_version]
+        parts += [self.base_image, self.cpu_version, self.gpu_version]
 
     return f'{FLAGS.base_url}:' + '-'.join(parts)
 
@@ -98,18 +117,70 @@ def _create_push_step(tag: str) -> BuildStep:
 
 
 # ----------------------------------------------------------------------------
-def _create_gpu_base_image_specs(cfg: Config) -> Dict[str, ImageSpec]:
-  return {
-      k: ImageSpec(base_image=None,
-                   gpu_version=k,
-                   build_args=v,
-                   dockerfile=_GPU_DOCKERFILE) for k, v in cfg.items()
-  }
+def _get_unique_gpu_bases(images: List[Config]) -> Set[GpuBase]:
+  gpu_base_images = set()
+
+  for x in images:
+    if x.get('gpu') is None:
+      continue
+    gpu_base_images.add(GpuBase(base_image=x['base_image'], gpu=x['gpu']))
+
+  return gpu_base_images
 
 
 # ----------------------------------------------------------------------------
-def _create_cpu_image_specs(cfg: Config) -> Dict[str, ImageSpec]:
-  return {k: ImageSpec(cpu_version=k, build_args=v) for k, v in cfg.items()}
+def _create_gpu_base_image_specs(
+    images: List[Config],
+    base_img_cfg: Config,
+    gpu_cfg: Config,
+) -> Dict[str, ImageSpec]:
+  specs = {}
+
+  for b in _get_unique_gpu_bases(images=images):
+    base = base_img_cfg[b.base_image]
+    build_args = copy(gpu_cfg[b.gpu])
+    build_args['UBUNTU_VERSION'] = base['UBUNTU_VERSION']
+
+    specs[b.tag] = ImageSpec(
+        base_image=b.base_image,
+        gpu_version=b.gpu,
+        build_args=build_args,
+        dockerfile=_GPU_DOCKERFILE,
+    )
+
+  return specs
+
+
+# ----------------------------------------------------------------------------
+def _get_unique_cpu_bases(images: List[Config]) -> Set[CpuBase]:
+  bases = set()
+  for x in images:
+    if x.get('gpu') is not None:
+      continue
+    bases.add(CpuBase(base_image=x['base_image'], python=x['python']))
+
+  return bases
+
+
+# ----------------------------------------------------------------------------
+def _create_cpu_image_specs(
+    images: List[Config],
+    base_img_cfg: Config,
+    cpu_cfg: Config,
+) -> Dict[str, ImageSpec]:
+
+  specs = {}
+  for b in _get_unique_cpu_bases(images):
+    base = base_img_cfg[b.base_image]
+    build_args = copy(cpu_cfg[b.python])
+    build_args['BASE_IMAGE'] = base["BASE_IMAGE"]
+
+    specs[b.tag] = ImageSpec(base_image=b.base_image,
+                             cpu_version=b.python,
+                             gpu_version=None,
+                             build_args=build_args)
+
+  return specs
 
 
 # ----------------------------------------------------------------------------
@@ -118,30 +189,49 @@ def _create_image_spec(
     cpu_specs: Dict[str, ImageSpec],
     gpu_specs: Dict[str, ImageSpec],
 ) -> ImageSpec:
-  gpu_version = cfg.get('gpu')
-  cpu_spec = cpu_specs[cfg.get('python')]
 
+  cpu_base = CpuBase(base_image=cfg['base_image'], python=cfg['python'])
+  cpu_spec = cpu_specs[cpu_base.tag]
+
+  gpu_version = cfg.get('gpu')
   if gpu_version is None:
     return cpu_spec
 
-  return ImageSpec(base_image=gpu_specs[gpu_version].tag,
+  gpu_base = GpuBase(base_image=cfg['base_image'], gpu=cfg['gpu'])
+  gpu_spec = gpu_specs[gpu_base.tag]
+
+  build_args = copy(cpu_spec.build_args)
+  build_args['BASE_IMAGE'] = gpu_spec.tag
+
+  return ImageSpec(base_image=cpu_spec.base_image,
                    cpu_version=cpu_spec.cpu_version,
                    gpu_version=gpu_version,
-                   build_args=cpu_spec.build_args)
+                   build_args=build_args)
 
 
 # ----------------------------------------------------------------------------
 def _create_specs(cfg: Dict[str, Any]) -> List[Dict[str, Any]]:
-  conda_cfg = cfg['python_versions']
-  cuda_cfg = cfg['gpu_versions']
+  gpu_cfg = cfg.get('gpu_versions', {})
+  python_cfg = cfg.get('python_versions', {})
+  base_img_cfg = cfg.get('base_images', {})
+  images = cfg.get('images', [])
 
-  gpu_specs = _create_gpu_base_image_specs(cfg.get('gpu_versions', {}))
-  cpu_specs = _create_cpu_image_specs(cfg.get('python_versions', {}))
+  gpu_specs = _create_gpu_base_image_specs(
+      images=images,
+      base_img_cfg=base_img_cfg,
+      gpu_cfg=gpu_cfg,
+  )
 
-  specs = list(gpu_specs.values())
+  cpu_specs = _create_cpu_image_specs(
+      images=images,
+      base_img_cfg=base_img_cfg,
+      cpu_cfg=python_cfg,
+  )
+
+  specs = list(gpu_specs.values())  # gpu base images
   specs += [
       _create_image_spec(cfg=c, cpu_specs=cpu_specs, gpu_specs=gpu_specs)
-      for c in cfg.get('images', [])
+      for c in images
   ]
 
   return specs
@@ -153,17 +243,13 @@ def _create_build_step(spec: ImageSpec) -> BuildStep:
   args += ['-t', spec.tag]
   args += ['-f', spec.dockerfile]
 
-  if spec.base_image is not None:
+  for k, v in spec.build_args.items():
     args.append('--build-arg')
-    args.append(f'BASE_IMAGE={spec.base_image}')
-
-  for a in spec.build_args:
-    args.append('--build-arg')
-    args.append(a)
+    args.append(f'{k}={v}')
   args.append('.')
 
   if spec.image_type == ImageType.GPU:
-    dependencies = [spec.base_image]
+    dependencies = [spec.build_args['BASE_IMAGE']]
   else:
     dependencies = ['-']
 
@@ -176,6 +262,10 @@ def main(argv):
     config = json.load(f)
 
   specs = _create_specs(cfg=config)
+
+  print(f'generating the following images in {FLAGS.output}:')
+  for s in specs:
+    print(f'{s.tag}')
 
   steps = []
   for s in specs:

--- a/scripts/cloudbuild_config.json
+++ b/scripts/cloudbuild_config.json
@@ -1,18 +1,25 @@
 {
   "gpu_versions" : {
-    "cuda100" : ["CUDA=10.0"],
-    "cuda101" : ["CUDA=10.1"]
+    "cuda100" : {"CUDA":"10.0"},
+    "cuda101" : {"CUDA":"10.1"},
+    "cuda110" : {"CUDA":"11.0"}
   },
   "python_versions" : {
-    "py37" : ["PYTHON_VERSION=3.7", "MINICONDA_VERSION=py37_4.8.2"],
-    "py38" : ["PYTHON_VERSION=3.8", "MINICONDA_VERSION=py38_4.8.2"]
+    "py37" : {"PYTHON_VERSION":"3.7", "MINICONDA_VERSION":"py37_4.8.2"},
+    "py38" : {"PYTHON_VERSION":"3.8", "MINICONDA_VERSION":"py38_4.8.2"}
+  },
+  "base_images" : {
+    "ubuntu1804" : {"BASE_IMAGE":"ubuntu:18.04", "UBUNTU_VERSION":"18.04"},
+    "ubuntu2004" : {"BASE_IMAGE":"ubuntu:20.04", "UBUNTU_VERSION":"20.04"}
   },
   "images" : [
-    {"python" : "py37"},
-    {"python" : "py38"},
-    {"python" : "py37", "gpu" : "cuda100"},
-    {"python" : "py37", "gpu" : "cuda101"},
-    {"python" : "py38", "gpu" : "cuda100"},
-    {"python" : "py38", "gpu" : "cuda101"}
+    {"base_image": "ubuntu1804", "python" : "py37"},
+    {"base_image": "ubuntu1804", "python" : "py38"},
+    {"base_image": "ubuntu1804", "python" : "py37", "gpu" : "cuda100"},
+    {"base_image": "ubuntu1804", "python" : "py37", "gpu" : "cuda101"},
+    {"base_image": "ubuntu1804", "python" : "py38", "gpu" : "cuda100"},
+    {"base_image": "ubuntu1804", "python" : "py38", "gpu" : "cuda101"},
+    {"base_image": "ubuntu2004", "python" : "py37"},
+    {"base_image": "ubuntu2004", "python" : "py38"}
   ]
 }


### PR DESCRIPTION
This PR adds support for generating caliban base images using different ubuntu base images, and also adds ubuntu 20.04 cpu base images to our cloudbuild configuration.

I ran this configuration manually, and the resulting tagged images can be found at `gcr.io/blueshift-playground/blueshift`