### PR TITLE
updated google-auth dependency version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ REQUIRED_PACKAGES = [
     'pyyaml',
     'tqdm>=4.45.0',
     'kubernetes>=10.0.1',
-    'google-auth>=1.18.0',
+    'google-auth>=1.19.0',
     'google-cloud-core>=1.0.3',
     'google-cloud-container>=0.3.0',
     'psycopg2-binary==2.8.5',


### PR DESCRIPTION
Just fixing a versioning issue for the `google-auth` package. This is for the `load_credentials_from_file` change in the auth package.