### PR TITLE
Prevent mlflow env vars from being generated when there is no mlflow config

### DIFF
--- a/caliban/platform/cloud/core.py
+++ b/caliban/platform/cloud/core.py
@@ -436,6 +436,7 @@ def _job_specs(
   for idx, m in enumerate(experiments, 1):
 
     launcher_args = um.mlflow_args(
+        caliban_config=caliban_config,
         experiment_name=m.xgroup.name,
         index=idx,
         tags={

--- a/caliban/platform/gke/cluster.py
+++ b/caliban/platform/gke/cluster.py
@@ -710,6 +710,7 @@ class Cluster(object):
     labels = labels or {}
 
     launcher_args = um.mlflow_args(
+        caliban_config=caliban_config,
         experiment_name=experiment.xgroup.name,
         index=index,
         tags={

--- a/caliban/platform/run.py
+++ b/caliban/platform/run.py
@@ -153,6 +153,7 @@ def _create_job_spec_dict(
   base_cmd = _run_cmd(job_mode, run_args) + terminal_cmds + [image_id]
 
   launcher_args = um.mlflow_args(
+      caliban_config=caliban_config,
       experiment_name=experiment.xgroup.name,
       index=index,
       tags={

--- a/caliban/util/metrics.py
+++ b/caliban/util/metrics.py
@@ -176,7 +176,7 @@ def mlflow_args(
 
   caliban_config: caliban configuration dict
   experiment: experiment object
-  index: job index, if < 0, then no run name is generated
+  index: job index
   tags: dictionary of tags to pass to mlflow
 
   Returns:

--- a/caliban/util/metrics.py
+++ b/caliban/util/metrics.py
@@ -166,6 +166,7 @@ def _mlflow_job_name(index: int, user: str = None) -> str:
 
 
 def mlflow_args(
+    caliban_config: Dict[str, Any],
     experiment_name: str,
     index: int,
     tags: Dict[str, Any],
@@ -173,13 +174,17 @@ def mlflow_args(
   '''returns mlflow args for caliban launcher
   Args:
 
+  caliban_config: caliban configuration dict
   experiment: experiment object
-  index: job index
+  index: job index, if < 0, then no run name is generated
   tags: dictionary of tags to pass to mlflow
 
   Returns:
   mlflow args list
   '''
+
+  if caliban_config.get('mlflow_config') is None:
+    return []
 
   env = {f'ENVVAR_{k}': v for k, v in tags.items()}
   env['MLFLOW_EXPERIMENT_NAME'] = experiment_name

--- a/tests/caliban/util/test_metrics.py
+++ b/tests/caliban/util/test_metrics.py
@@ -44,7 +44,44 @@ def test_mlflow_args():
   '''verifies that we generate the dynamic args for the caliban launcher
   script for mlflow integration'''
 
+  # test case when caliban_config has no mlflow configuration
   cfg = {
+      'caliban_config': {
+          'base_image': 'gcr.io/a/b'
+      },
+      'experiment_name': 'foo',
+      'index': 42,
+      'tags': {
+          'a': 'x',
+          'b': 7
+      },
+  }
+
+  mlflow_args = um.mlflow_args(**cfg)
+  assert len(mlflow_args) == 0
+
+  # test case when caliban_config has empty mlflow configuration
+  cfg = {
+      'caliban_config': {
+          'base_image': 'gcr.io/a/b',
+          'mlflow_config': None
+      },
+      'experiment_name': 'foo',
+      'index': 42,
+      'tags': {
+          'a': 'x',
+          'b': 7
+      },
+  }
+
+  mlflow_args = um.mlflow_args(**cfg)
+  assert len(mlflow_args) == 0
+
+  # test case when caliban_config has mlflow configuration
+  cfg = {
+      'caliban_config': {
+          'mlflow_config': {}
+      },
       'experiment_name': 'foo',
       'index': 42,
       'tags': {


### PR DESCRIPTION
This PR prevents mlflow environment variables from being generated when there is no mlflow configuration in `.calibanconfig.json`.