### PR TITLE
Fix image ID parsing in modern Docker

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.6
+        python-version: 3.11
     - name: Cache pip
       uses: actions/cache@v2
       with:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -12,5 +12,5 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
       with:
-        python-version: 3.6
+        python-version: 3.11
     - uses: pre-commit/action@v2.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.6
+    - name: Set up Python 3.11
       uses: actions/setup-python@v2
       with:
-        python-version: '3.6'
+        python-version: 3.11
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: ["3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # pending
 
+- #109:
+
+  - Upgrades `psycopg2-binary` and `pytest` to get tests passing again with
+    modern Python.
+
+  - Modifies `docker build` commands to get the built image ID via `--iidfile`
+    vs parsing the shell command output.
+
+  - adds `--platform linux/amd64` to `docker run` and `docker build` commands,
+    until we get support for `arm64` sorted out.
+
+  - fixes failure when GCP credentials aren't configured running in local mode.
+
 # 0.4.1
 
 Small release to archive for JOSS acceptance.

--- a/caliban/platform/run.py
+++ b/caliban/platform/run.py
@@ -61,7 +61,8 @@ def _run_cmd(job_mode: c.JobMode,
     run_args = []
 
   runtime = ["--runtime", "nvidia"] if c.gpu(job_mode) else []
-  return ["docker", "run"] + runtime + ["--ipc", "host"] + run_args
+  return ["docker", "run", "--platform", "linux/amd64"
+         ] + runtime + ["--ipc", "host"] + run_args
 
 
 def log_job_spec_instance(job_spec: JobSpec, i: int) -> JobSpec:

--- a/caliban/resources/caliban_launcher.py
+++ b/caliban/resources/caliban_launcher.py
@@ -150,7 +150,12 @@ def _ensure_non_null_project(env):
   if 'GOOGLE_CLOUD_PROJECT' in env:
     return env
 
-  _, project_id = google.auth.default()
+  project_id = None
+  try:
+    _, project_id = google.auth.default()
+  except:
+    project_id = None
+
   if project_id is not None:
     return env
 

--- a/caliban/util/fs.py
+++ b/caliban/util/fs.py
@@ -254,8 +254,7 @@ def capture_stdout(cmd: List[str],
                         stdin=subprocess.PIPE,
                         stdout=subprocess.PIPE,
                         stderr=subprocess.STDOUT,
-                        universal_newlines=False,
-                        bufsize=1) as p:
+                        universal_newlines=False) as p:
     if input_str:
       p.stdin.write(input_str.encode('utf-8'))
     p.stdin.close()

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@
 hypothesis
 ipython
 pre-commit
-pytest==5.4.3
-pytest-cov==2.10.0
-pytest-subprocess==0.1.5
+pytest==7.3.2
+pytest-cov==4.1.0
+pytest-subprocess==1.5.0
 twine

--- a/setup.py
+++ b/setup.py
@@ -48,14 +48,10 @@ REQUIRED_PACKAGES = [
     'google-auth>=1.19.0',
     'google-cloud-core>=1.0.3',
     'google-cloud-container>=0.3.0',
-    'psycopg2-binary==2.8.5',
+    'psycopg2-binary==2.9.6',
     'schema==0.7.2',
     'urllib3>=1.25.7',
     'yaspin>=0.16.0',
-    # This is not a real dependency of ours, but we need it to override the
-    # dep that commentjson brings in. Delete once this is merged:
-    # https://github.com/vaidik/commentjson/pull/33/files
-    'lark-parser>=0.7.1,<0.8.0',
     'SQLAlchemy==1.3.11',
     'pg8000==1.16.1',
 ]

--- a/tests/caliban/platform/gke/test_util.py
+++ b/tests/caliban/platform/gke/test_util.py
@@ -802,7 +802,7 @@ def test_export_job():
     assert util.export_job(j, fname)
     assert os.path.exists(fname)
     with open(fname, 'r') as f:
-      x = yaml.load(f)
+      x = yaml.safe_load(f)
     assert x == nnd
 
     fname = os.path.join(tmpdir, 'foo.xyz')


### PR DESCRIPTION
This PR:

  - Upgrades `psycopg2-binary` and `pytest` to get tests passing again with
    modern Python.

  - Modifies `docker build` commands to get the built image ID via `--iidfile`
    vs parsing the shell command output.

  - adds `--platform linux/amd64` to `docker run` and `docker build` commands,
    until we get support for `arm64` sorted out.

  - fixes failure when GCP credentials aren't configured running in local mode.