### PR TITLE
Fix failure on missing google.auth inside container

### DIFF
--- a/caliban/resources/caliban_launcher.py
+++ b/caliban/resources/caliban_launcher.py
@@ -20,7 +20,7 @@ job.
 
 import argparse
 import copy
-import google.auth
+from importlib.util import find_spec
 import json
 import logging
 import os
@@ -153,7 +153,13 @@ def _ensure_non_null_project(env):
 
   project_id = None
   try:
-    _, project_id = google.auth.default()
+    if find_spec("google.auth") is not None:
+      import google.auth
+
+      _, project_id = google.auth.default()
+    else:
+      project_id = None
+
   except Exception:
     project_id = None
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,6 +5,11 @@ addopts = --doctest-modules -v -s
 [pycodestyle]
 ignore = E111,E114
 
+[yapf]
+based_on_style = google
+indent_width = 2
+split_before_first_argument = false
+
 # pytest coverage options
 [run]
 omit =


### PR DESCRIPTION
This PR fixes a case identified by @georgematheos where `caliban run` fails when running in a project where `google-auth` is not installed. The solution is to use `find_spec` to check if google.auth is available on the classpath and use it only in that case.